### PR TITLE
Add check-dist guard so the committed bundle stays in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
   check-dist:
     runs-on: ubuntu-latest
     name: Check dist is up to date
+    permissions:
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,33 @@ jobs:
     - name: Run pre-commit hooks
       run: pre-commit run --all-files
 
+  check-dist:
+    runs-on: ubuntu-latest
+    name: Check dist is up to date
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: 24
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Rebuild the dist bundle
+      run: npm run package
+
+    - name: Verify dist matches the committed bundle
+      run: |
+        if [ -n "$(git status --porcelain dist/)" ]; then
+          echo "::error::dist/ is out of date. Run 'npm run package' and commit the result."
+          git --no-pager diff --stat dist/
+          exit 1
+        fi
+
   test:
     runs-on: ubuntu-latest
     name: Test Coverage Treemap Action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,11 @@ jobs:
         fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
 
     - name: Dump Github context
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
       run: |
         set -x
-        echo '${{ toJSON(github) }}'
+        echo "$GITHUB_CONTEXT"
         git log --oneline
         echo "base-depth=${{ steps.base-depth.outputs.base-depth }}"
         git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,12 @@ repos:
   rev: v0.13.0
   hooks:
   - id: yamlfmt
+
+- repo: local
+  hooks:
+  - id: package-dist
+    name: package dist bundle
+    entry: npm run package
+    language: system
+    pass_filenames: false
+    files: ^(src/.*|package\.json|package-lock\.json|tsconfig\.json)$


### PR DESCRIPTION
## What

- New `check-dist` CI job: rebuilds the ncc bundle (`npm run package`) and fails the run if `dist/` differs from what's committed.
- New local pre-commit hook `package-dist`: repackages `dist/` whenever `src/`, `package.json`, `package-lock.json`, or `tsconfig.json` change.

## Why

GitHub Actions runs `runs.main` (`dist/index.js`) straight from the checked-out ref, so the bundle must be committed. This guard ensures the checked-in bundle can never drift from the TypeScript source — the standard pattern used by `actions/typescript-action`. It's the reviewed-in-PR alternative to a post-merge auto-commit (which would land unreviewed, non-reproducible artifacts on main).