### PR TITLE
Fix dump-context CI failure on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
     steps:
     - name: Determine fetch depth
       id: base-depth
-      run: echo "base-depth=$(expr ${{ github.event.pull_request.commits }} + 1)" | tee -a $GITHUB_OUTPUT
+      env:
+        PR_COMMITS: ${{ github.event.pull_request.commits }}
+      run: echo "base-depth=$(expr "${PR_COMMITS:-0}" + 1)" | tee -a $GITHUB_OUTPUT
 
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -78,12 +80,18 @@ jobs:
     - name: Dump Github context
       env:
         GITHUB_CONTEXT: ${{ toJSON(github) }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         set -x
         echo "$GITHUB_CONTEXT"
         git log --oneline
         echo "base-depth=${{ steps.base-depth.outputs.base-depth }}"
-        git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+          git diff "$BASE_SHA..$HEAD_SHA"
+        else
+          echo "Not a pull_request event; skipping base..head diff."
+        fi
       shell: bash
 
     - name: Setup Node.js


### PR DESCRIPTION
## What

The `Dump Github context` step in CI failed on `main` (a `push` event) with:

```
fatal: ..: '..' is outside repository
##[error]Process completed with exit code 128.
```

On `push` events, `github.event.pull_request.base.sha` and `head.sha` are empty, so the step expanded to `git diff ..`, which git rejects.

## Fix

- Only run the `base..head` diff when both SHAs are present (i.e. on `pull_request`); otherwise print a note and continue.
- Pass the SHAs via env vars instead of inlining them into the script.
- Default the fetch depth to 1 when `pull_request.commits` is empty (push events) so `expr` doesn't choke.

## Testing

Validated the workflow with pre-commit (yamllint, actionlint pinning). The diff branch will exercise the pull_request path; the push path on merge to main will exercise the guarded branch.