### PR TITLE
Run the coveragemap self-test only on pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
         retention-days: 3
 
     - name: Run Coveragemap action
+      # The action analyses the diff of a pull request and needs the PR head
+      # SHA, which only exists on pull_request events. On push (e.g. the merge
+      # to main) there is no PR context, so skip the self-test there.
+      if: github.event_name == 'pull_request'
       uses: ./
       id: coveragemap
       with:


### PR DESCRIPTION
## Problem

After the dump-context fix landed, CI on `main` still failed:

```
Error: Failed to detect changes in pull request: Error: PR head SHA not available in GitHub context
```

The `Run Coveragemap action` step dogfoods the action against the current diff, but the action analyses a **pull request's** diff and needs `github.context.payload.pull_request.head.sha`. On a `push` event (the merge to main) there is no PR context, so it throws.

## Fix

Gate the self-test step with `if: github.event_name == 'pull_request'`. The test/build/coverage-upload steps still run on push, so main keeps verifying the bundle and tests — only the PR-diff dogfooding (which is meaningless without a PR) is skipped.

## Testing

pre-commit (yamllint/actionlint pinning) clean. The PR run will exercise the gated step on `pull_request`; the merge to main will exercise the skip path.