### PR TITLE
Improve coverage comment card: neutral diff indicator and grouped line counts

### DIFF
--- a/src/prComment.test.ts
+++ b/src/prComment.test.ts
@@ -3,6 +3,7 @@ import {
   CommentData,
   generateCommentBody,
   formatFileSize,
+  formatLineCount,
 } from "./prComment";
 import { CoverageAnalysis } from "./coverageAnalyzer";
 import { LcovReport } from "./lcov";
@@ -271,9 +272,9 @@ describe("PrCommentService", () => {
       const result = generateCommentBody(commentData, gatingResult);
 
       expect(result).toContain("## Coveragemap Action: Test");
-      expect(result).toContain("| **Total Coverage** | 80% | 800/1000 |");
+      expect(result).toContain("| **Total Coverage** | 80% | 800/1,000 |");
       expect(result).toContain("| **Changed Files** | 80% | 40/50 |");
-      expect(result).toContain("| **Difference** | 📈 +0% | - |");
+      expect(result).toContain("| **Difference** | ➖ 0% | - |");
       expect(result).toContain("| **Threshold** | ✅ 75% | - |");
       expect(result).toContain("✅ `src/example.ts` | 80% | 40/50");
     });
@@ -477,6 +478,68 @@ describe("PrCommentService", () => {
       expect(formatFileSize(1536)).toBe("1.5 KB");
       expect(formatFileSize(1048576)).toBe("1.0 MB");
       expect(formatFileSize(1073741824)).toBe("1.0 GB");
+    });
+  });
+
+  describe("formatLineCount", () => {
+    test("should add thousands separators to large counts", () => {
+      expect(formatLineCount(63162)).toBe("63,162");
+      expect(formatLineCount(100542)).toBe("100,542");
+      expect(formatLineCount(1000)).toBe("1,000");
+    });
+
+    test("should leave small counts untouched", () => {
+      expect(formatLineCount(0)).toBe("0");
+      expect(formatLineCount(42)).toBe("42");
+    });
+  });
+
+  describe("difference indicator", () => {
+    const buildBody = (coverageDifference: number): string => {
+      const service = new PrCommentService({ githubToken: "test-token" });
+      const commentData: CommentData = {
+        totalCoverage: { linesHit: 63162, linesFound: 100542, percentage: 63 },
+        changedFilesCoverage: { linesHit: 0, linesFound: 0, percentage: 100 },
+        coverageDifference,
+        fileBreakdown: [],
+      };
+      const gatingResult: GatingResult = {
+        meetsThreshold: true,
+        threshold: 0,
+        mode: "baseline",
+        prCoveragePercentage: 100,
+        overallProjectCoveragePercentage: 63,
+        description: "baseline",
+      };
+      return (
+        service as unknown as {
+          generateCommentBody: (
+            data: CommentData,
+            gatingResult: GatingResult,
+          ) => string;
+        }
+      ).generateCommentBody.bind(service)(commentData, gatingResult);
+    };
+
+    test("shows a neutral indicator when coverage is unchanged", () => {
+      const result = buildBody(0);
+      expect(result).toContain("| **Difference** | ➖ 0% | - |");
+      expect(result).not.toContain("📈");
+      expect(result).not.toContain("📉");
+    });
+
+    test("shows an up indicator with a plus sign for improvements", () => {
+      expect(buildBody(5.5)).toContain("| **Difference** | 📈 +5.5% | - |");
+    });
+
+    test("shows a down indicator for regressions", () => {
+      expect(buildBody(-3.2)).toContain("| **Difference** | 📉 -3.2% | - |");
+    });
+
+    test("renders large line counts with thousands separators", () => {
+      expect(buildBody(0)).toContain(
+        "| **Total Coverage** | 63% | 63,162/100,542 |",
+      );
     });
   });
 

--- a/src/prComment.ts
+++ b/src/prComment.ts
@@ -95,8 +95,13 @@ export class PrCommentService {
   ): string {
     const title = this.getCommentTitle();
     const thresholdEmoji = gatingResult.meetsThreshold ? "✅" : "❌";
-    const diffEmoji = data.coverageDifference >= 0 ? "📈" : "📉";
-    const diffSign = data.coverageDifference >= 0 ? "+" : "";
+    const diffEmoji =
+      data.coverageDifference > 0
+        ? "📈"
+        : data.coverageDifference < 0
+          ? "📉"
+          : "➖";
+    const diffSign = data.coverageDifference > 0 ? "+" : "";
 
     const thresholdDisplay =
       gatingResult.mode === "baseline"
@@ -108,8 +113,18 @@ export class PrCommentService {
     // Summary table
     markdown += `| Metric | Coverage | Lines |\n`;
     markdown += `|--------|----------|-------|\n`;
-    markdown += `| **Total Coverage** | ${data.totalCoverage.percentage}% | ${data.totalCoverage.linesHit}/${data.totalCoverage.linesFound} |\n`;
-    markdown += `| **Changed Files** | ${data.changedFilesCoverage.percentage}% | ${data.changedFilesCoverage.linesHit}/${data.changedFilesCoverage.linesFound} |\n`;
+    markdown += `| **Total Coverage** | ${
+      data.totalCoverage.percentage
+    }% | ${this.formatLines(
+      data.totalCoverage.linesHit,
+      data.totalCoverage.linesFound,
+    )} |\n`;
+    markdown += `| **Changed Files** | ${
+      data.changedFilesCoverage.percentage
+    }% | ${this.formatLines(
+      data.changedFilesCoverage.linesHit,
+      data.changedFilesCoverage.linesFound,
+    )} |\n`;
     markdown += `| **Difference** | ${diffEmoji} ${diffSign}${data.coverageDifference}% | - |\n`;
     markdown += `| **Threshold** | ${thresholdEmoji} ${thresholdDisplay} | - |\n\n`;
 
@@ -125,7 +140,9 @@ export class PrCommentService {
             ? file.percentage >= gatingResult.overallProjectCoveragePercentage!
             : file.percentage >= gatingResult.threshold;
         const fileEmoji = fileThresholdMet ? "✅" : "❌";
-        markdown += `| ${fileEmoji} \`${file.filename}\` | ${file.percentage}% | ${file.linesHit}/${file.linesFound} |\n`;
+        markdown += `| ${fileEmoji} \`${file.filename}\` | ${
+          file.percentage
+        }% | ${this.formatLines(file.linesHit, file.linesFound)} |\n`;
       }
       markdown += `\n`;
     }
@@ -237,6 +254,14 @@ export class PrCommentService {
   }
 
   /**
+   * Format a hit/found line pair with thousands separators so large
+   * line counts stay readable (e.g. 63162/100542 -> 63,162/100,542).
+   */
+  private formatLines(linesHit: number, linesFound: number): string {
+    return `${formatLineCount(linesHit)}/${formatLineCount(linesFound)}`;
+  }
+
+  /**
    * Format file size in human readable format
    */
   private formatFileSize(bytes: number): string {
@@ -311,6 +336,13 @@ export function generateCommentBody(
       ) => string;
     }
   ).generateCommentBody(commentData, gatingResult, artifactInfo);
+}
+
+/**
+ * Format an integer line count with locale-aware thousands separators.
+ */
+export function formatLineCount(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
 }
 
 /**

--- a/src/prComment.ts
+++ b/src/prComment.ts
@@ -338,11 +338,18 @@ export function generateCommentBody(
   ).generateCommentBody(commentData, gatingResult, artifactInfo);
 }
 
+// Reused across every line-pair we render so we don't allocate a new
+// formatter on each call. Rounds to whole numbers since line counts are
+// always integers.
+const LINE_COUNT_FORMATTER = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
+
 /**
- * Format an integer line count with locale-aware thousands separators.
+ * Format a line count with en-US thousands separators (e.g. 100542 -> 100,542).
  */
 export function formatLineCount(value: number): string {
-  return new Intl.NumberFormat("en-US").format(value);
+  return LINE_COUNT_FORMATTER.format(value);
 }
 
 /**


### PR DESCRIPTION
## What

- Show a **neutral indicator** (`➖`, no `+` sign) on the **Difference** row when changed-file coverage equals the project average, instead of a misleading `📈 +0%`. Up/down arrows are unchanged for real improvements/regressions.
- Add **thousands separators** to all line counts in the comment (Total Coverage, Changed Files, and per-file rows), e.g. `63162/100542` → `63,162/100,542`, so large totals are readable.

## How

- `prComment.ts`: tri-state `diffEmoji` (`📈`/`📉`/`➖`), `diffSign` only adds `+` for positive deltas, and a new `formatLineCount` helper using `Intl.NumberFormat("en-US")` applied via `formatLines(hit, found)`.

## Tests

- Added `formatLineCount` unit tests and a difference-indicator suite covering neutral/up/down and grouped line counts. All 23 `prComment` tests pass.
- Rebuilt the ncc `dist` bundle; pre-commit (prettier + package-dist) clean.