### PR TITLE
Render placeholders when a PR changes no covered lines

### DIFF
--- a/src/prComment.test.ts
+++ b/src/prComment.test.ts
@@ -499,7 +499,7 @@ describe("PrCommentService", () => {
       const service = new PrCommentService({ githubToken: "test-token" });
       const commentData: CommentData = {
         totalCoverage: { linesHit: 63162, linesFound: 100542, percentage: 63 },
-        changedFilesCoverage: { linesHit: 0, linesFound: 0, percentage: 100 },
+        changedFilesCoverage: { linesHit: 45, linesFound: 50, percentage: 90 },
         coverageDifference,
         fileBreakdown: [],
       };
@@ -507,7 +507,7 @@ describe("PrCommentService", () => {
         meetsThreshold: true,
         threshold: 0,
         mode: "baseline",
-        prCoveragePercentage: 100,
+        prCoveragePercentage: 90,
         overallProjectCoveragePercentage: 63,
         description: "baseline",
       };
@@ -540,6 +540,46 @@ describe("PrCommentService", () => {
       expect(buildBody(0)).toContain(
         "| **Total Coverage** | 63% | 63,162/100,542 |",
       );
+    });
+  });
+
+  describe("no changed lines", () => {
+    const buildBody = (): string => {
+      const service = new PrCommentService({ githubToken: "test-token" });
+      const commentData: CommentData = {
+        totalCoverage: { linesHit: 63162, linesFound: 100542, percentage: 63 },
+        changedFilesCoverage: { linesHit: 0, linesFound: 0, percentage: 100 },
+        coverageDifference: 37.18,
+        fileBreakdown: [],
+      };
+      const gatingResult: GatingResult = {
+        meetsThreshold: true,
+        threshold: 0,
+        mode: "baseline",
+        prCoveragePercentage: 100,
+        overallProjectCoveragePercentage: 63,
+        description: "baseline",
+      };
+      return (
+        service as unknown as {
+          generateCommentBody: (
+            data: CommentData,
+            gatingResult: GatingResult,
+          ) => string;
+        }
+      ).generateCommentBody.bind(service)(commentData, gatingResult);
+    };
+
+    test("renders dashes instead of a misleading 100%/diff/checkmark", () => {
+      const result = buildBody();
+      expect(result).toContain("| **Changed Files** | – | – |");
+      expect(result).toContain("| **Difference** | – | - |");
+      expect(result).toContain(
+        "| **Threshold** | ➖ ≥ Project Avg (63%) (no changed lines) | - |",
+      );
+      expect(result).not.toContain("100%");
+      expect(result).not.toContain("📈");
+      expect(result).not.toContain("✅");
     });
   });
 

--- a/src/prComment.ts
+++ b/src/prComment.ts
@@ -94,19 +94,37 @@ export class PrCommentService {
     treemapArtifact?: ArtifactInfo,
   ): string {
     const title = this.getCommentTitle();
-    const thresholdEmoji = gatingResult.meetsThreshold ? "✅" : "❌";
-    const diffEmoji =
-      data.coverageDifference > 0
-        ? "📈"
-        : data.coverageDifference < 0
-          ? "📉"
-          : "➖";
-    const diffSign = data.coverageDifference > 0 ? "+" : "";
+
+    // When the PR touches no lines that carry coverage data there is nothing
+    // to compare, so we render placeholders instead of a misleading 100% /
+    // +diff / green threshold.
+    const hasChangedLines = data.changedFilesCoverage.linesFound > 0;
 
     const thresholdDisplay =
       gatingResult.mode === "baseline"
         ? `≥ Project Avg (${gatingResult.overallProjectCoveragePercentage}%)`
         : `${gatingResult.threshold}%`;
+
+    const changedFilesCell = hasChangedLines
+      ? `${data.changedFilesCoverage.percentage}% | ${this.formatLines(
+          data.changedFilesCoverage.linesHit,
+          data.changedFilesCoverage.linesFound,
+        )}`
+      : `– | –`;
+
+    const differenceCell = hasChangedLines
+      ? `${
+          data.coverageDifference > 0
+            ? "📈"
+            : data.coverageDifference < 0
+              ? "📉"
+              : "➖"
+        } ${data.coverageDifference > 0 ? "+" : ""}${data.coverageDifference}%`
+      : `–`;
+
+    const thresholdCell = hasChangedLines
+      ? `${gatingResult.meetsThreshold ? "✅" : "❌"} ${thresholdDisplay}`
+      : `➖ ${thresholdDisplay} (no changed lines)`;
 
     let markdown = `## ${title}\n\n`;
 
@@ -119,14 +137,9 @@ export class PrCommentService {
       data.totalCoverage.linesHit,
       data.totalCoverage.linesFound,
     )} |\n`;
-    markdown += `| **Changed Files** | ${
-      data.changedFilesCoverage.percentage
-    }% | ${this.formatLines(
-      data.changedFilesCoverage.linesHit,
-      data.changedFilesCoverage.linesFound,
-    )} |\n`;
-    markdown += `| **Difference** | ${diffEmoji} ${diffSign}${data.coverageDifference}% | - |\n`;
-    markdown += `| **Threshold** | ${thresholdEmoji} ${thresholdDisplay} | - |\n\n`;
+    markdown += `| **Changed Files** | ${changedFilesCell} |\n`;
+    markdown += `| **Difference** | ${differenceCell} | - |\n`;
+    markdown += `| **Threshold** | ${thresholdCell} | - |\n\n`;
 
     // File breakdown if there are any files with coverage data
     if (data.fileBreakdown.length > 0) {


### PR DESCRIPTION
## What

When a PR touches **no lines that carry coverage data** (changed-file line total is 0), the card previously showed a misleading **100%** for Changed Files, a **+diff** vs project average, and a **green ✅ Threshold**. There is nothing to compare in that case.

Now, when there are zero changed lines:
- **Changed Files** → `– | –`
- **Difference** → `–`
- **Threshold** → `➖ ≥ Project Avg (63%) (no changed lines)` (neutral, not a green checkmark)

Total Coverage is unaffected. The normal up/down/neutral indicators and grouped line counts still apply whenever there *are* changed lines.

## How

`prComment.ts`: `generateCommentBody` computes `hasChangedLines = changedFilesCoverage.linesFound > 0` and renders placeholder cells for the Changed Files / Difference / Threshold rows when false.

## Tests

- New `no changed lines` suite asserting dashes and the neutral threshold, and that `100%`/`📈`/`✅` are absent.
- Updated the difference-indicator suite to use non-zero changed lines. All 24 `prComment` tests pass; `dist` rebuilt, pre-commit clean.