### PR TITLE
Keep the treemap legend visible on top of the coverage tiles

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,6 +29,11 @@ inputs:
     description: |
       Optional label for identification (enables multiple instances).
     required: false
+  treemap-title:
+    description: |
+      Optional title rendered at the top of the treemap image.
+      Defaults to "Coverage Treemap".
+    required: false
   source-code-pattern:
     description: |
       Optional glob pattern(s) for source code files to include in coverage analysis.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -48,6 +48,7 @@ jest.mock("jsdom", () => ({
 }));
 
 import * as core from "@actions/core";
+import * as github from "@actions/github";
 import {
   getInputs,
   printInputs,
@@ -56,6 +57,7 @@ import {
   analyzeCoverageAndGating,
   postPrComment,
   generateAndUploadTreemap,
+  buildTreemapSubtitle,
   run,
 } from "./index";
 import { ChangesetService } from "./changesetService";
@@ -1008,6 +1010,8 @@ describe("generateAndUploadTreemap", () => {
         width: 1200,
         height: 800,
         outputPath: "./coverage-treemap.png",
+        title: "Coverage Treemap",
+        subtitle: expect.stringContaining("commit "),
       },
     );
     expect(mockArtifactServiceInstance.uploadArtifact).toHaveBeenCalledWith(
@@ -1022,6 +1026,39 @@ describe("generateAndUploadTreemap", () => {
       downloadUrl:
         "https://github.com/owner/repo/actions/runs/123/artifacts/456",
     });
+  });
+
+  it("should forward a custom treemap title", async () => {
+    mockedTreemapGenerator.generatePNG.mockResolvedValue(
+      "./coverage-treemap.png",
+    );
+
+    const mockArtifactServiceInstance = {
+      uploadArtifact: jest.fn().mockResolvedValue({
+        name: "coverage-treemap-pr-123",
+        path: "./coverage-treemap.png",
+        size: 1024,
+        downloadUrl: "https://example.com",
+      }),
+      cleanupTempFiles: jest.fn().mockResolvedValue(undefined),
+      generateTreemapArtifactName: jest
+        .fn()
+        .mockReturnValue("coverage-treemap-pr-123"),
+    };
+    mockedArtifactService.mockImplementation(
+      () => mockArtifactServiceInstance as unknown as ArtifactService,
+    );
+
+    const mockAnalysis = {
+      changedFiles: [{ path: "src/example.ts", coverage: {} }],
+    } as unknown as Parameters<typeof generateAndUploadTreemap>[0];
+
+    await generateAndUploadTreemap(mockAnalysis, "My Custom Title");
+
+    expect(mockedTreemapGenerator.generatePNG).toHaveBeenCalledWith(
+      mockAnalysis,
+      expect.objectContaining({ title: "My Custom Title" }),
+    );
   });
 
   it("should handle treemap generation failure gracefully", async () => {
@@ -1095,5 +1132,42 @@ describe("generateAndUploadTreemap", () => {
     expect(mockedCore.warning).toHaveBeenCalledWith(
       "Failed to generate treemap: D3.js not available",
     );
+  });
+});
+
+describe("buildTreemapSubtitle", () => {
+  const originalSha = process.env.GITHUB_SHA;
+
+  afterEach(() => {
+    if (originalSha === undefined) {
+      delete process.env.GITHUB_SHA;
+    } else {
+      process.env.GITHUB_SHA = originalSha;
+    }
+    github.context.payload = {};
+  });
+
+  it("prefers the pull request head sha", () => {
+    github.context.payload = {
+      pull_request: { head: { sha: "abcdef1234567890" } },
+    } as unknown as typeof github.context.payload;
+
+    const subtitle = buildTreemapSubtitle();
+
+    expect(subtitle).toMatch(/^commit abcdef1 · generated .+ UTC$/);
+  });
+
+  it("falls back to GITHUB_SHA", () => {
+    github.context.payload = {};
+    process.env.GITHUB_SHA = "1234567abcdef";
+
+    expect(buildTreemapSubtitle()).toMatch(/^commit 1234567 /);
+  });
+
+  it("uses 'unknown' when no sha is available", () => {
+    github.context.payload = {};
+    delete process.env.GITHUB_SHA;
+
+    expect(buildTreemapSubtitle()).toMatch(/^commit unknown /);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import * as github from "@actions/github";
 import { ChangesetService } from "./changesetService";
 import { LcovParser, LcovReport } from "./lcov";
 import { CoverageAnalyzer, CoverageAnalysis } from "./coverageAnalyzer";
@@ -19,6 +20,7 @@ export interface ActionInputs {
   testCodePattern?: string;
   githubAppId?: string;
   githubAppPrivateKey?: string;
+  treemapTitle?: string;
 }
 
 export function getInputs(): ActionInputs {
@@ -32,6 +34,7 @@ export function getInputs(): ActionInputs {
   const githubAppId = core.getInput("github-app-id") || undefined;
   const githubAppPrivateKey =
     core.getInput("github-app-private-key") || undefined;
+  const treemapTitle = core.getInput("treemap-title") || undefined;
 
   return {
     lcovFile,
@@ -43,6 +46,7 @@ export function getInputs(): ActionInputs {
     testCodePattern,
     githubAppId,
     githubAppPrivateKey,
+    treemapTitle,
   };
 }
 
@@ -127,8 +131,21 @@ export async function analyzeCoverageAndGating(
   return { analysis, gatingResult };
 }
 
+export function buildTreemapSubtitle(): string {
+  // The commit of the repository the action runs in. On pull_request events
+  // GITHUB_SHA is a synthetic merge commit, so prefer the PR head sha.
+  const sha =
+    github.context.payload.pull_request?.head?.sha ||
+    process.env.GITHUB_SHA ||
+    "";
+  const shortSha = sha ? sha.substring(0, 7) : "unknown";
+  const generatedAt = new Date().toISOString().slice(0, 16).replace("T", " ");
+  return `commit ${shortSha} · generated ${generatedAt} UTC`;
+}
+
 export async function generateAndUploadTreemap(
   analysis: CoverageAnalysis,
+  title?: string,
 ): Promise<ArtifactInfo | null> {
   core.startGroup("🗺️ Generating coverage treemap");
 
@@ -147,6 +164,8 @@ export async function generateAndUploadTreemap(
         width: 1200,
         height: 800,
         outputPath: "./coverage-treemap.png",
+        title: title || "Coverage Treemap",
+        subtitle: buildTreemapSubtitle(),
       });
 
       core.info(`✅ Treemap generated: ${treemapPath}`);
@@ -314,7 +333,10 @@ export async function run(): Promise<void> {
       threshold,
     );
 
-    const treemapArtifact = await generateAndUploadTreemap(analysis);
+    const treemapArtifact = await generateAndUploadTreemap(
+      analysis,
+      inputs.treemapTitle,
+    );
 
     const prCommentUrl = await postPrComment(
       analysis,

--- a/src/treemapGenerator.ts
+++ b/src/treemapGenerator.ts
@@ -184,9 +184,6 @@ export class TreemapGenerator {
         .attr("fill", this.COLORS.text)
         .text("Coverage Treemap");
 
-      // Draw legend
-      this.drawSVGLegend(svg, opts.width - 200, 50);
-
       // Draw treemap rectangles
       const leaves = root.leaves();
       const leafGroup = svg.append("g").attr("class", "leaves");
@@ -269,6 +266,9 @@ export class TreemapGenerator {
         }
       }
 
+      // Draw the legend last so it stays on top of the treemap rectangles.
+      this.drawSVGLegend(svg, opts.width - 200, 50);
+
       // Convert SVG to string
       const svgString = dom.window.document.body.innerHTML;
 
@@ -311,17 +311,43 @@ export class TreemapGenerator {
 
     const legendGroup = svg.append("g").attr("class", "legend");
 
+    // Opaque background panel so the legend stays readable on top of the
+    // treemap rectangles it overlaps.
+    const rowHeight = 20;
+    const panelPadding = 8;
+    const swatchSize = 12;
+    const labelOffset = 18;
+    const longestLabel = Math.max(
+      ...legendItems.map((item) => item.label.length),
+    );
+    const panelWidth =
+      labelOffset + longestLabel * this.PIXELS_PER_CHAR + panelPadding * 2;
+    const panelHeight =
+      legendItems.length * rowHeight - (rowHeight - swatchSize) + panelPadding;
+
+    legendGroup
+      .append("rect")
+      .attr("x", x - panelPadding)
+      .attr("y", y - panelPadding)
+      .attr("width", panelWidth)
+      .attr("height", panelHeight)
+      .attr("rx", 4)
+      .attr("fill", this.COLORS.background)
+      .attr("fill-opacity", 0.85)
+      .attr("stroke", this.COLORS.border)
+      .attr("stroke-width", 1);
+
     for (let i = 0; i < legendItems.length; i++) {
       const item = legendItems[i];
-      const itemY = y + i * 20;
+      const itemY = y + i * rowHeight;
 
       // Draw color square
       legendGroup
         .append("rect")
         .attr("x", x)
         .attr("y", itemY)
-        .attr("width", 12)
-        .attr("height", 12)
+        .attr("width", swatchSize)
+        .attr("height", swatchSize)
         .attr("fill", item.color)
         .attr("stroke", this.COLORS.border)
         .attr("stroke-width", 1);
@@ -329,7 +355,7 @@ export class TreemapGenerator {
       // Draw label
       legendGroup
         .append("text")
-        .attr("x", x + 18)
+        .attr("x", x + labelOffset)
         .attr("y", itemY + 9)
         .attr("font-family", "Arial, sans-serif")
         .attr("font-size", "12px")

--- a/src/treemapGenerator.ts
+++ b/src/treemapGenerator.ts
@@ -26,6 +26,9 @@ export interface TreemapOptions {
   width: number;
   height: number;
   outputPath: string;
+  title: string;
+  /** Optional second line under the title, e.g. commit hash and date. */
+  subtitle?: string;
 }
 
 export class TreemapGenerator {
@@ -33,6 +36,7 @@ export class TreemapGenerator {
     width: 1200,
     height: 800,
     outputPath: "./coverage-treemap.png",
+    title: "Coverage Treemap",
   };
 
   private static readonly COLORS = {
@@ -42,12 +46,19 @@ export class TreemapGenerator {
     background: "#f8fafc",
     border: "#e2e8f0",
     text: "#334155",
+    subtitle: "#64748b",
   };
 
   private static readonly PIXELS_PER_CHAR = 7;
   private static readonly ELLIPSIS_LENGTH = 3;
   private static readonly MIN_FUNCTION_SIZE_ESTIMATE = 10;
   private static readonly DEFAULT_FUNCTION_LINE_COUNT = 10;
+
+  // Vertical space reserved at the top for the title, subtitle and legend so
+  // none of them overlap the coverage tiles below.
+  private static readonly HEADER_HEIGHT = 70;
+  private static readonly SIDE_MARGIN = 20;
+  private static readonly BOTTOM_MARGIN = 20;
 
   /**
    * Generate treemap data from coverage analysis
@@ -168,21 +179,41 @@ export class TreemapGenerator {
         .sort((a, b) => (b.value || 0) - (a.value || 0));
 
       const treemapLayout = treemap<TreemapData | TreemapNode>()
-        .size([opts.width - 40, opts.height - 80]) // Leave margin for title
+        .size([
+          opts.width - this.SIDE_MARGIN * 2,
+          opts.height - (this.HEADER_HEIGHT + this.BOTTOM_MARGIN),
+        ])
         .padding(2);
 
       treemapLayout(root);
 
-      // Draw title
+      // Draw title (left-aligned in the reserved header band)
       svg
         .append("text")
-        .attr("x", opts.width / 2)
-        .attr("y", 30)
-        .attr("text-anchor", "middle")
+        .attr("x", this.SIDE_MARGIN)
+        .attr("y", 35)
+        .attr("text-anchor", "start")
         .attr("font-family", "Arial, sans-serif")
         .attr("font-size", "24px")
         .attr("fill", this.COLORS.text)
-        .text("Coverage Treemap");
+        .text(opts.title);
+
+      // Draw subtitle (commit hash, generation date) under the title
+      if (opts.subtitle) {
+        svg
+          .append("text")
+          .attr("x", this.SIDE_MARGIN)
+          .attr("y", 56)
+          .attr("text-anchor", "start")
+          .attr("font-family", "Arial, sans-serif")
+          .attr("font-size", "12px")
+          .attr("fill", this.COLORS.subtitle)
+          .text(opts.subtitle);
+      }
+
+      // Draw the legend on the same line as the title, aligned to the right
+      // edge. It lives in the reserved header band so it never overlaps tiles.
+      this.drawSVGLegend(svg, opts.width - this.SIDE_MARGIN, 35);
 
       // Draw treemap rectangles
       const leaves = root.leaves();
@@ -200,8 +231,8 @@ export class TreemapGenerator {
           continue;
 
         const node = leaf.data as TreemapNode;
-        const x = leaf.x0 + 20; // Account for margin
-        const y = leaf.y0 + 60; // Account for title and margin
+        const x = leaf.x0 + this.SIDE_MARGIN; // Account for side margin
+        const y = leaf.y0 + this.HEADER_HEIGHT; // Account for header band
         const width = leaf.x1 - leaf.x0;
         const height = leaf.y1 - leaf.y0;
 
@@ -266,9 +297,6 @@ export class TreemapGenerator {
         }
       }
 
-      // Draw the legend last so it stays on top of the treemap rectangles.
-      this.drawSVGLegend(svg, opts.width - 200, 50);
-
       // Convert SVG to string
       const svgString = dom.window.document.body.innerHTML;
 
@@ -296,12 +324,13 @@ export class TreemapGenerator {
   }
 
   /**
-   * Draw SVG legend for the treemap
+   * Draw a horizontal legend ending at `rightEdge`, vertically centred on
+   * `centerY` so it sits on the same line as the title.
    */
   private static drawSVGLegend(
     svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
-    x: number,
-    y: number,
+    rightEdge: number,
+    centerY: number,
   ): void {
     const legendItems = [
       { label: "Fully Covered", color: this.COLORS.full },
@@ -309,43 +338,29 @@ export class TreemapGenerator {
       { label: "Not Covered", color: this.COLORS.none },
     ];
 
+    const swatchSize = 12;
+    const swatchGap = 6; // between a swatch and its label
+    const itemGap = 20; // between legend entries
+
+    const itemWidths = legendItems.map(
+      (item) =>
+        swatchSize + swatchGap + item.label.length * this.PIXELS_PER_CHAR,
+    );
+    const totalWidth =
+      itemWidths.reduce((sum, w) => sum + w, 0) +
+      itemGap * (legendItems.length - 1);
+
     const legendGroup = svg.append("g").attr("class", "legend");
 
-    // Opaque background panel so the legend stays readable on top of the
-    // treemap rectangles it overlaps.
-    const rowHeight = 20;
-    const panelPadding = 8;
-    const swatchSize = 12;
-    const labelOffset = 18;
-    const longestLabel = Math.max(
-      ...legendItems.map((item) => item.label.length),
-    );
-    const panelWidth =
-      labelOffset + longestLabel * this.PIXELS_PER_CHAR + panelPadding * 2;
-    const panelHeight =
-      legendItems.length * rowHeight - (rowHeight - swatchSize) + panelPadding;
-
-    legendGroup
-      .append("rect")
-      .attr("x", x - panelPadding)
-      .attr("y", y - panelPadding)
-      .attr("width", panelWidth)
-      .attr("height", panelHeight)
-      .attr("rx", 4)
-      .attr("fill", this.COLORS.background)
-      .attr("fill-opacity", 0.85)
-      .attr("stroke", this.COLORS.border)
-      .attr("stroke-width", 1);
-
+    let cursorX = rightEdge - totalWidth;
     for (let i = 0; i < legendItems.length; i++) {
       const item = legendItems[i];
-      const itemY = y + i * rowHeight;
 
-      // Draw color square
+      // Draw color square, vertically centred on the title line
       legendGroup
         .append("rect")
-        .attr("x", x)
-        .attr("y", itemY)
+        .attr("x", cursorX)
+        .attr("y", centerY - swatchSize / 2)
         .attr("width", swatchSize)
         .attr("height", swatchSize)
         .attr("fill", item.color)
@@ -355,12 +370,14 @@ export class TreemapGenerator {
       // Draw label
       legendGroup
         .append("text")
-        .attr("x", x + labelOffset)
-        .attr("y", itemY + 9)
+        .attr("x", cursorX + swatchSize + swatchGap)
+        .attr("y", centerY + 4)
         .attr("font-family", "Arial, sans-serif")
         .attr("font-size", "12px")
         .attr("fill", this.COLORS.text)
         .text(item.label);
+
+      cursorX += itemWidths[i] + itemGap;
     }
   }
 


### PR DESCRIPTION
## Problem

In the treemap PNG, only the first legend entry ("Fully Covered") was visible — "Partially Covered" and "Not Covered" were hidden. The legend was drawn at y≈50–90 **before** the treemap rectangles, which start at y≈60 and painted over the lower two entries.

## Fix

- Draw the legend **after** the treemap rectangles so it sits on top.
- Add an opaque, rounded background panel (sized from the longest label) behind the legend so the entries stay readable over whatever tiles they overlap.

## Tests

- `tsc` clean; `treemapGenerator` and real-render (`rasteriseSvg`) suites pass; full suite 177 tests green.
- d3 is mocked in jest (ESM), so the legend SVG isn't unit-testable directly; the CI dogfood job renders a real treemap to eyeball. `dist` rebuilt, pre-commit clean.