### PR TITLE
Add type-check, CodeQL, dependency-review, concurrency and release tag CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,15 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -61,6 +67,22 @@ jobs:
           exit 1
         fi
 
+  dependency-review:
+    runs-on: ubuntu-latest
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+    - name: Review dependencies
+      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      with:
+        comment-summary-in-pr: on-failure
+
   test:
     runs-on: ubuntu-latest
     name: Test Coverage Treemap Action
@@ -102,6 +124,9 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
+
+    - name: Type check
+      run: npm run build -- --noEmit
 
     - name: Run tests with coverage
       run: npm run test:coverage

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+  - cron: "30 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-extended
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-major-tag:
+    name: Update major version tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      with:
+        fetch-depth: 0
+
+    - name: Move major version tag
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+      run: |-
+        set -euo pipefail
+        if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::notice::Release tag '$RELEASE_TAG' is not a vX.Y.Z tag; skipping major tag update."
+          exit 0
+        fi
+        MAJOR_TAG="${RELEASE_TAG%%.*}"
+        echo "Pointing $MAJOR_TAG at $RELEASE_TAG"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git tag -f "$MAJOR_TAG" "$RELEASE_TAG"
+        git push origin "refs/tags/$MAJOR_TAG" --force


### PR DESCRIPTION
## Summary

Adds the higher-value CI checks that were missing for this GitHub Action.

### CI workflow (`ci.yml`)
- **Type check**: run `tsc --noEmit` in the test job so type errors that `ncc` would transpile past are caught.
- **Concurrency**: cancel superseded runs on the same PR/branch to save minutes.
- **Permission hardening**: scope the `pre-commit` job to `contents: read` instead of inheriting workflow-level `pull-requests: write`.
- **Dependency review**: gate PRs on vulnerable / disallowed-license dependency introductions (complements Renovate's reactive alerts).

### New workflows
- **CodeQL** (`codeql.yml`): SAST for JS/TS on push, PR, and weekly schedule with `security-extended` queries.
- **Release** (`release.yml`): on a published `vX.Y.Z` release, force-move the major tag (e.g. `v1`) so consumers can pin `@v1`.

All new actions are pinned by digest to satisfy the `check-gha-pinning` hook.

## Testing
- `npm run build -- --noEmit`, `npm run test` (181 passing), and `pre-commit run` on all three workflow files pass locally.
- Workflow behaviour (CodeQL upload, dependency-review gating, release tag move) validated by inspection; these can only fully exercise on GitHub.