### PR TITLE
Restyle treemap with ticker tiles and new palette

### DIFF
--- a/src/treemapGenerator.test.ts
+++ b/src/treemapGenerator.test.ts
@@ -63,6 +63,68 @@ describe("TreemapGenerator", () => {
     jest.clearAllMocks();
   });
 
+  describe("colorForCoverage", () => {
+    it.each([
+      { coverage: "full" as const, color: "#4ecdc4" },
+      { coverage: "partial" as const, color: "#ffe66d" },
+      { coverage: "none" as const, color: "#ff6b6b" },
+    ])(
+      "maps $coverage coverage to the $color palette colour",
+      ({ coverage, color }) => {
+        expect(TreemapGenerator.colorForCoverage(coverage)).toBe(color);
+      },
+    );
+  });
+
+  describe("formatTickerLines", () => {
+    it("builds ticker rows with name, percentage and line count", () => {
+      const result = TreemapGenerator.formatTickerLines({
+        name: "example.ts::doWork",
+        file: "src/example.ts",
+        value: 10,
+        coverage: "partial",
+        lineCount: 10,
+        coveredLines: 3,
+        functionName: "doWork",
+      });
+
+      expect(result).toEqual({
+        name: "doWork",
+        percent: "30%",
+        lines: "3/10 lines",
+      });
+    });
+
+    it("falls back to the file basename when no function name is set", () => {
+      const result = TreemapGenerator.formatTickerLines({
+        name: "script.ts",
+        file: "src/nested/script.ts",
+        value: 4,
+        coverage: "full",
+        lineCount: 4,
+        coveredLines: 4,
+      });
+
+      expect(result.name).toBe("script.ts");
+      expect(result.percent).toBe("100%");
+      expect(result.lines).toBe("4/4 lines");
+    });
+
+    it("reports 0% without dividing by zero for empty tiles", () => {
+      const result = TreemapGenerator.formatTickerLines({
+        name: "empty.ts",
+        file: "src/empty.ts",
+        value: 1,
+        coverage: "none",
+        lineCount: 0,
+        coveredLines: 0,
+      });
+
+      expect(result.percent).toBe("0%");
+      expect(result.lines).toBe("0/0 lines");
+    });
+  });
+
   describe("generateTreemapData", () => {
     it("should generate treemap data for files with coverage", () => {
       const mockAnalysis: CoverageAnalysis = {

--- a/src/treemapGenerator.ts
+++ b/src/treemapGenerator.ts
@@ -39,14 +39,17 @@ export class TreemapGenerator {
     title: "Coverage Treemap",
   };
 
+  // Palette sourced from the "1A535C / 4ECDC4 / F7FFF7 / FF6B6B / FFE66D"
+  // scheme: deep teal anchors the text, with teal/yellow/coral encoding the
+  // coverage states against a soft mint background.
   private static readonly COLORS = {
-    full: "#22c55e", // Green for full coverage
-    partial: "#f59e0b", // Orange for partial coverage
-    none: "#ef4444", // Red for no coverage
-    background: "#f8fafc",
-    border: "#e2e8f0",
-    text: "#334155",
-    subtitle: "#64748b",
+    full: "#4ecdc4", // Teal for full coverage
+    partial: "#ffe66d", // Yellow for partial coverage
+    none: "#ff6b6b", // Coral for no coverage
+    background: "#f7fff7", // Soft mint
+    border: "#1a535c", // Deep teal
+    text: "#1a535c", // Deep teal
+    subtitle: "#4a7a82", // Muted teal
   };
 
   private static readonly PIXELS_PER_CHAR = 7;
@@ -241,53 +244,57 @@ export class TreemapGenerator {
         .attr("y", y)
         .attr("width", width)
         .attr("height", height)
-        .attr(
-          "fill",
-          this.COLORS[node.coverage as keyof typeof this.COLORS] ||
-            this.COLORS.none,
-        )
+        .attr("fill", this.colorForCoverage(node.coverage))
         .attr("stroke", this.COLORS.border)
         .attr("stroke-width", 1);
 
-      // Draw text if rectangle is large enough
+      // Draw "ticker style" labels when the tile is large enough: the name
+      // sits at the top like a ticker symbol, with the coverage percentage as
+      // the headline figure in the middle and the line count beneath it.
       if (width > 80 && height > 30) {
         const textGroup = nodeGroup.append("g");
+        const centerX = x + width / 2;
+        const ticker = this.formatTickerLines(node);
 
-        // Function/file name
-        const name = node.functionName || path.basename(node.file);
+        // Symbol (file/class/function name) pinned to the top.
         textGroup
           .append("text")
-          .attr("x", x + 5)
-          .attr("y", y + 15)
+          .attr("x", centerX)
+          .attr("y", y + 16)
+          .attr("text-anchor", "middle")
           .attr("font-family", "Arial, sans-serif")
           .attr("font-size", "12px")
+          .attr("font-weight", "bold")
+          .attr("letter-spacing", "0.5")
           .attr("fill", this.COLORS.text)
-          .text(this.truncateText(name, width - 10));
+          .text(this.truncateText(ticker.name, width - 10));
 
-        // Coverage info
         if (height > 50) {
-          const coverageText = `${node.coveredLines}/${node.lineCount} lines`;
+          const centerY = y + height / 2;
+
+          // Headline percentage, centred like a ticker quote.
           textGroup
             .append("text")
-            .attr("x", x + 5)
-            .attr("y", y + 30)
+            .attr("x", centerX)
+            .attr("y", centerY + 4)
+            .attr("text-anchor", "middle")
             .attr("font-family", "Arial, sans-serif")
-            .attr("font-size", "10px")
+            .attr("font-size", "22px")
+            .attr("font-weight", "bold")
             .attr("fill", this.COLORS.text)
-            .text(coverageText);
+            .text(ticker.percent);
 
           if (height > 70) {
-            const percentText = `${Math.round(
-              (node.coveredLines / node.lineCount) * 100,
-            )}%`;
+            // Covered/total line count just below the headline figure.
             textGroup
               .append("text")
-              .attr("x", x + 5)
-              .attr("y", y + 45)
+              .attr("x", centerX)
+              .attr("y", centerY + 22)
+              .attr("text-anchor", "middle")
               .attr("font-family", "Arial, sans-serif")
-              .attr("font-size", "10px")
+              .attr("font-size", "11px")
               .attr("fill", this.COLORS.text)
-              .text(percentText);
+              .text(this.truncateText(ticker.lines, width - 10));
           }
         }
       }
@@ -361,6 +368,35 @@ export class TreemapGenerator {
 
       cursorX += itemWidths[i] + itemGap;
     }
+  }
+
+  /**
+   * Resolve the tile fill colour for a coverage state.
+   */
+  static colorForCoverage(coverage: TreemapNode["coverage"]): string {
+    return this.COLORS[coverage] ?? this.COLORS.none;
+  }
+
+  /**
+   * Build the three "ticker style" text rows for a tile: the symbol (name) on
+   * top, the coverage percentage as the headline figure in the middle, and the
+   * covered/total line count underneath.
+   */
+  static formatTickerLines(node: TreemapNode): {
+    name: string;
+    percent: string;
+    lines: string;
+  } {
+    const percentValue =
+      node.lineCount > 0
+        ? Math.round((node.coveredLines / node.lineCount) * 100)
+        : 0;
+
+    return {
+      name: node.functionName || path.basename(node.file),
+      percent: `${percentValue}%`,
+      lines: `${node.coveredLines}/${node.lineCount} lines`,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Refreshes the coverage treemap visualization design.

- **Palette:** Adopts the `1A535C / 4ECDC4 / F7FFF7 / FF6B6B / FFE66D` scheme from the requested screenshot. Coverage states now map to teal (full), yellow (partial) and coral (none) on a soft mint background, with deep teal text and borders.
- **Ticker-style tiles:** Each tile now reads like a stock ticker — the file/class/function name sits at the top as the "symbol", the coverage percentage is the centred headline figure, and the covered/total line count sits just beneath it. Text is centre-aligned per tile.
- Extracted `colorForCoverage()` and `formatTickerLines()` as pure helpers so the colour mapping and label layout are unit-testable.

## Testing

- Added unit tests covering the palette mapping and ticker label formatting, including the divide-by-zero guard for empty tiles.
- Manually verified the bundled `dist/index.js` still reaches input parsing (`node dist/index.js`).