### PR TITLE
Prefix tile function names with file basename

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -8,6 +8,7 @@ const execAsync = promisify(exec);
 export class GitUtils {
   static getPullRequestHead(): string {
     // Use GitHub context which is most reliable for PR events
+    // (the GitHub Actions context is populated from the event payload).
     if (context.payload.pull_request?.head?.sha) {
       const contextSha = context.payload.pull_request.head.sha;
       core.info(`📌 Using PR head from GitHub context: ${contextSha}`);

--- a/src/treemapGenerator.render.test.ts
+++ b/src/treemapGenerator.render.test.ts
@@ -1,0 +1,186 @@
+import { TreemapGenerator } from "./treemapGenerator";
+import { CoverageAnalysis } from "./coverageAnalyzer";
+import * as fs from "fs";
+
+// Render with the real d3, d3-hierarchy and linkedom so the SVG drawing path
+// (file group boxes + function tiles) actually executes. Only the WASM
+// rasteriser and the filesystem write are stubbed so the test stays hermetic.
+jest.mock("./svgRasteriser", () => ({
+  rasteriseSvgToPng: jest.fn(async () => Buffer.from("fake-png")),
+}));
+
+jest.mock("fs");
+
+import { rasteriseSvgToPng } from "./svgRasteriser";
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+const mockedRasterise = rasteriseSvgToPng as jest.MockedFunction<
+  typeof rasteriseSvgToPng
+>;
+
+function fileWithFunctions(
+  filePath: string,
+  functions: { name: string; line: number; hit: number }[],
+  lines: { line: number; hit: number }[],
+) {
+  const coveredLines = lines.filter((l) => l.hit > 0).length;
+  return {
+    path: filePath,
+    status: "modified" as const,
+    coverage: {
+      path: filePath,
+      functions,
+      lines,
+      branches: [],
+      summary: {
+        functionsFound: functions.length,
+        functionsHit: functions.filter((f) => f.hit > 0).length,
+        linesFound: lines.length,
+        linesHit: coveredLines,
+        branchesFound: 0,
+        branchesHit: 0,
+      },
+    },
+    analysis: {
+      totalLines: lines.length,
+      coveredLines,
+      totalFunctions: functions.length,
+      coveredFunctions: functions.filter((f) => f.hit > 0).length,
+      totalBranches: 0,
+      coveredBranches: 0,
+      linesCoveragePercentage: (coveredLines / lines.length) * 100,
+      functionsCoveragePercentage: 0,
+      branchesCoveragePercentage: 0,
+      overallCoveragePercentage: (coveredLines / lines.length) * 100,
+    },
+  };
+}
+
+describe("TreemapGenerator rendering", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFs.writeFileSync.mockImplementation(() => {});
+    mockedRasterise.mockResolvedValue(Buffer.from("fake-png"));
+  });
+
+  it("draws file group boxes and function tiles into the SVG", async () => {
+    const analysis: CoverageAnalysis = {
+      changeset: {
+        baseCommit: "abc123",
+        headCommit: "def456",
+        targetBranch: "main",
+        files: [],
+        totalFiles: 2,
+      },
+      changedFiles: [
+        fileWithFunctions(
+          "src/alpha.ts",
+          [
+            { name: "doWork", line: 1, hit: 3 },
+            { name: "helper", line: 40, hit: 0 },
+          ],
+          Array.from({ length: 80 }, (_, i) => ({
+            line: i + 1,
+            hit: i < 40 ? 1 : 0,
+          })),
+        ),
+        // File with coverage but no functions -> single file-level tile.
+        {
+          path: "src/beta.ts",
+          status: "modified",
+          coverage: {
+            path: "src/beta.ts",
+            functions: [],
+            lines: Array.from({ length: 30 }, (_, i) => ({
+              line: i + 1,
+              hit: 1,
+            })),
+            branches: [],
+            summary: {
+              functionsFound: 0,
+              functionsHit: 0,
+              linesFound: 30,
+              linesHit: 30,
+              branchesFound: 0,
+              branchesHit: 0,
+            },
+          },
+          analysis: {
+            totalLines: 30,
+            coveredLines: 30,
+            totalFunctions: 0,
+            coveredFunctions: 0,
+            totalBranches: 0,
+            coveredBranches: 0,
+            linesCoveragePercentage: 100,
+            functionsCoveragePercentage: 0,
+            branchesCoveragePercentage: 0,
+            overallCoveragePercentage: 100,
+          },
+        },
+        // File without coverage data -> single uncovered tile.
+        {
+          path: "src/gamma.ts",
+          status: "added",
+          coverage: undefined,
+          analysis: {
+            totalLines: 25,
+            coveredLines: 0,
+            totalFunctions: 0,
+            coveredFunctions: 0,
+            totalBranches: 0,
+            coveredBranches: 0,
+            linesCoveragePercentage: 0,
+            functionsCoveragePercentage: 0,
+            branchesCoveragePercentage: 0,
+            overallCoveragePercentage: 0,
+          },
+        },
+      ],
+      summary: {
+        totalChangedFiles: 3,
+        filesWithCoverage: 2,
+        filesWithoutCoverage: 1,
+        overallCoverage: {
+          totalLines: 135,
+          coveredLines: 70,
+          totalFunctions: 2,
+          coveredFunctions: 1,
+          totalBranches: 0,
+          coveredBranches: 0,
+          linesCoveragePercentage: 51.85,
+          functionsCoveragePercentage: 50,
+          branchesCoveragePercentage: 0,
+          overallCoveragePercentage: 51.85,
+        },
+      },
+    };
+
+    await TreemapGenerator.generatePNG(analysis, {
+      title: "Coverage Treemap",
+      subtitle: "commit def456 · today",
+      outputPath: "./out.png",
+    });
+
+    expect(mockedRasterise).toHaveBeenCalledTimes(1);
+    const svg = mockedRasterise.mock.calls[0][0];
+
+    // File path labels are drawn on the group headers.
+    expect(svg).toContain("src/alpha.ts");
+    expect(svg).toContain("src/beta.ts");
+    expect(svg).toContain("src/gamma.ts");
+
+    // Function names appear on tiles without a file prefix.
+    expect(svg).toContain("doWork");
+    expect(svg).toContain("helper");
+
+    // Title and subtitle are rendered in the header band.
+    expect(svg).toContain("Coverage Treemap");
+    expect(svg).toContain("commit def456");
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      "./out.png",
+      expect.any(Buffer),
+    );
+  });
+});

--- a/src/treemapGenerator.test.ts
+++ b/src/treemapGenerator.test.ts
@@ -50,6 +50,9 @@ jest.mock("d3-hierarchy", () => ({
     const mockTreemap: Record<string, any> = jest.fn();
     mockTreemap.size = jest.fn().mockReturnValue(mockTreemap);
     mockTreemap.padding = jest.fn().mockReturnValue(mockTreemap);
+    mockTreemap.paddingOuter = jest.fn().mockReturnValue(mockTreemap);
+    mockTreemap.paddingTop = jest.fn().mockReturnValue(mockTreemap);
+    mockTreemap.paddingInner = jest.fn().mockReturnValue(mockTreemap);
     return mockTreemap;
   }),
 }));
@@ -79,7 +82,7 @@ describe("TreemapGenerator", () => {
   describe("formatTickerLines", () => {
     it("builds ticker rows with name, percentage and line count", () => {
       const result = TreemapGenerator.formatTickerLines({
-        name: "example.ts::doWork",
+        name: "doWork",
         file: "src/example.ts",
         value: 10,
         coverage: "partial",
@@ -89,13 +92,13 @@ describe("TreemapGenerator", () => {
       });
 
       expect(result).toEqual({
-        name: "example.ts › doWork",
+        name: "doWork",
         percent: "30%",
         lines: "3/10 lines",
       });
     });
 
-    it("falls back to the file basename when no function name is set", () => {
+    it("returns an empty name for file-level tiles without a function", () => {
       const result = TreemapGenerator.formatTickerLines({
         name: "script.ts",
         file: "src/nested/script.ts",
@@ -105,14 +108,14 @@ describe("TreemapGenerator", () => {
         coveredLines: 4,
       });
 
-      expect(result.name).toBe("script.ts");
+      expect(result.name).toBe("");
       expect(result.percent).toBe("100%");
       expect(result.lines).toBe("4/4 lines");
     });
 
-    it("prefixes the function name with the file basename only", () => {
+    it("uses the function name verbatim without a file prefix", () => {
       const result = TreemapGenerator.formatTickerLines({
-        name: "deep/path/widget.ts::render",
+        name: "render",
         file: "src/deep/path/widget.ts",
         value: 8,
         coverage: "partial",
@@ -121,7 +124,7 @@ describe("TreemapGenerator", () => {
         functionName: "render",
       });
 
-      expect(result.name).toBe("widget.ts › render");
+      expect(result.name).toBe("render");
     });
 
     it("reports 0% without dividing by zero for empty tiles", () => {
@@ -220,17 +223,22 @@ describe("TreemapGenerator", () => {
       const result = TreemapGenerator.generateTreemapData(mockAnalysis);
 
       expect(result.name).toBe("Coverage Analysis");
-      expect(result.children).toHaveLength(2); // Two functions
+      expect(result.children).toHaveLength(1); // One file group
 
-      const testFunction = result.children.find(
-        (child) => child.name === "example.ts::testFunction",
+      const fileGroup = result.children[0];
+      expect(fileGroup.name).toBe("example.ts");
+      expect(fileGroup.file).toBe("src/example.ts");
+      expect(fileGroup.children).toHaveLength(2); // Two functions
+
+      const testFunction = fileGroup.children.find(
+        (child) => child.name === "testFunction",
       );
       expect(testFunction).toBeDefined();
       expect(testFunction?.coverage).toBe("partial"); // 2 out of 10 lines covered
       expect(testFunction?.functionName).toBe("testFunction");
 
-      const anotherFunction = result.children.find(
-        (child) => child.name === "example.ts::anotherFunction",
+      const anotherFunction = fileGroup.children.find(
+        (child) => child.name === "anotherFunction",
       );
       expect(anotherFunction).toBeDefined();
       expect(anotherFunction?.coverage).toBe("none"); // 0 lines covered
@@ -288,8 +296,10 @@ describe("TreemapGenerator", () => {
 
       expect(result.children).toHaveLength(1);
       expect(result.children[0].name).toBe("uncovered.ts");
-      expect(result.children[0].coverage).toBe("none");
-      expect(result.children[0].value).toBe(20);
+      const uncoveredTile = result.children[0].children[0];
+      expect(uncoveredTile.name).toBe("uncovered.ts");
+      expect(uncoveredTile.coverage).toBe("none");
+      expect(uncoveredTile.value).toBe(20);
     });
 
     it("should handle files with coverage but no functions", () => {
@@ -360,8 +370,9 @@ describe("TreemapGenerator", () => {
 
       expect(result.children).toHaveLength(1);
       expect(result.children[0].name).toBe("script.ts");
-      expect(result.children[0].coverage).toBe("partial"); // 66.67%
-      expect(result.children[0].functionName).toBeUndefined();
+      const scriptTile = result.children[0].children[0];
+      expect(scriptTile.coverage).toBe("partial"); // 66.67%
+      expect(scriptTile.functionName).toBeUndefined();
     });
 
     it("should mark a fully covered function as full", () => {
@@ -436,8 +447,8 @@ describe("TreemapGenerator", () => {
 
       const result = TreemapGenerator.generateTreemapData(mockAnalysis);
 
-      const fullFn = result.children.find(
-        (child) => child.name === "full.ts::fullFn",
+      const fullFn = result.children[0].children.find(
+        (child) => child.name === "fullFn",
       );
       expect(fullFn?.coverage).toBe("full");
     });
@@ -510,7 +521,7 @@ describe("TreemapGenerator", () => {
         const result = TreemapGenerator.generateTreemapData(mockAnalysis);
 
         expect(result.children).toHaveLength(1);
-        expect(result.children[0].coverage).toBe(expected);
+        expect(result.children[0].children[0].coverage).toBe(expected);
       },
     );
   });

--- a/src/treemapGenerator.test.ts
+++ b/src/treemapGenerator.test.ts
@@ -89,7 +89,7 @@ describe("TreemapGenerator", () => {
       });
 
       expect(result).toEqual({
-        name: "doWork",
+        name: "example.ts › doWork",
         percent: "30%",
         lines: "3/10 lines",
       });
@@ -108,6 +108,20 @@ describe("TreemapGenerator", () => {
       expect(result.name).toBe("script.ts");
       expect(result.percent).toBe("100%");
       expect(result.lines).toBe("4/4 lines");
+    });
+
+    it("prefixes the function name with the file basename only", () => {
+      const result = TreemapGenerator.formatTickerLines({
+        name: "deep/path/widget.ts::render",
+        file: "src/deep/path/widget.ts",
+        value: 8,
+        coverage: "partial",
+        lineCount: 8,
+        coveredLines: 6,
+        functionName: "render",
+      });
+
+      expect(result.name).toBe("widget.ts › render");
     });
 
     it("reports 0% without dividing by zero for empty tiles", () => {

--- a/src/treemapGenerator.ts
+++ b/src/treemapGenerator.ts
@@ -17,9 +17,20 @@ export interface TreemapNode {
   functionName?: string;
 }
 
+/**
+ * A file groups its function tiles together. The file path is drawn once on
+ * the group's header border so individual function tiles only need to show the
+ * function name.
+ */
+export interface TreemapFileGroup {
+  name: string; // file basename, used as the group header label
+  file: string; // full file path
+  children: TreemapNode[];
+}
+
 export interface TreemapData {
   name: string;
-  children: TreemapNode[];
+  children: TreemapFileGroup[];
 }
 
 export interface TreemapOptions {
@@ -63,28 +74,41 @@ export class TreemapGenerator {
   private static readonly SIDE_MARGIN = 20;
   private static readonly BOTTOM_MARGIN = 20;
 
+  // Height of the per-file header band that carries the file path label.
+  private static readonly FILE_HEADER_HEIGHT = 18;
+
   /**
    * Generate treemap data from coverage analysis
    */
   static generateTreemapData(analysis: CoverageAnalysis): TreemapData {
-    const children: TreemapNode[] = [];
+    const children: TreemapFileGroup[] = [];
 
     for (const file of analysis.changedFiles) {
+      const basename = path.basename(file.path);
+
       if (!file.coverage) {
-        // File without coverage data - treat as uncovered
+        // File without coverage data - treat as a single uncovered tile.
         children.push({
-          name: path.basename(file.path),
+          name: basename,
           file: file.path,
-          value: Math.max(file.analysis.totalLines, 1), // Ensure minimum size
-          coverage: "none",
-          lineCount: file.analysis.totalLines,
-          coveredLines: 0,
+          children: [
+            {
+              name: basename,
+              file: file.path,
+              value: Math.max(file.analysis.totalLines, 1),
+              coverage: "none",
+              lineCount: file.analysis.totalLines,
+              coveredLines: 0,
+            },
+          ],
         });
         continue;
       }
 
-      // Process functions in the file
       if (file.coverage.functions.length > 0) {
+        // One tile per function, grouped under the file.
+        const functionTiles: TreemapNode[] = [];
+
         for (const func of file.coverage.functions) {
           const functionLines = this.getFunctionLineCount(func, file.coverage);
           const coveredLines = this.getFunctionCoveredLines(
@@ -101,8 +125,8 @@ export class TreemapGenerator {
             coverage = "partial";
           }
 
-          children.push({
-            name: `${path.basename(file.path)}::${func.name}`,
+          functionTiles.push({
+            name: func.name,
             file: file.path,
             value: Math.max(functionLines, 1), // Ensure minimum size
             coverage,
@@ -111,8 +135,14 @@ export class TreemapGenerator {
             functionName: func.name,
           });
         }
+
+        children.push({
+          name: basename,
+          file: file.path,
+          children: functionTiles,
+        });
       } else {
-        // File has coverage but no functions - treat as file-level coverage
+        // File has coverage but no functions - single file-level tile.
         const coverageRatio = file.analysis.linesCoveragePercentage / 100;
         let coverage: "full" | "partial" | "none";
         if (coverageRatio === 0) {
@@ -124,12 +154,18 @@ export class TreemapGenerator {
         }
 
         children.push({
-          name: path.basename(file.path),
+          name: basename,
           file: file.path,
-          value: Math.max(file.analysis.totalLines, 1),
-          coverage,
-          lineCount: file.analysis.totalLines,
-          coveredLines: file.analysis.coveredLines,
+          children: [
+            {
+              name: basename,
+              file: file.path,
+              value: Math.max(file.analysis.totalLines, 1),
+              coverage,
+              lineCount: file.analysis.totalLines,
+              coveredLines: file.analysis.coveredLines,
+            },
+          ],
         });
       }
     }
@@ -173,16 +209,21 @@ export class TreemapGenerator {
       .attr("fill", this.COLORS.background);
 
     // Create D3 treemap layout
-    const root = hierarchy<TreemapData | TreemapNode>(data)
+    const root = hierarchy<TreemapData | TreemapFileGroup | TreemapNode>(data)
       .sum((d) => (d as TreemapNode).value || 0)
       .sort((a, b) => (b.value || 0) - (a.value || 0));
 
-    const treemapLayout = treemap<TreemapData | TreemapNode>()
+    const treemapLayout = treemap<
+      TreemapData | TreemapFileGroup | TreemapNode
+    >()
       .size([
         opts.width - this.SIDE_MARGIN * 2,
         opts.height - (this.HEADER_HEIGHT + this.BOTTOM_MARGIN),
       ])
-      .padding(2);
+      .paddingOuter(2)
+      // Reserve a header band on each file group for its path label.
+      .paddingTop((d) => (d.depth === 1 ? this.FILE_HEADER_HEIGHT : 2))
+      .paddingInner(2);
 
     treemapLayout(root);
 
@@ -214,12 +255,70 @@ export class TreemapGenerator {
     // edge. It lives in the reserved header band so it never overlaps tiles.
     this.drawSVGLegend(svg, opts.width - this.SIDE_MARGIN, 35);
 
-    // Draw treemap rectangles
+    // Draw a labelled box around each file's functions. The file path lives on
+    // this header once, so the function tiles below only show the function
+    // name.
+    const fileGroupLayer = svg.append("g").attr("class", "file-groups");
+
+    for (const group of (root.children ?? []) as HierarchyRectangularNode<
+      TreemapData | TreemapFileGroup | TreemapNode
+    >[]) {
+      if (
+        group.x0 === undefined ||
+        group.y0 === undefined ||
+        group.x1 === undefined ||
+        group.y1 === undefined
+      )
+        continue;
+
+      const groupData = group.data as TreemapFileGroup;
+      const gx = group.x0 + this.SIDE_MARGIN;
+      const gy = group.y0 + this.HEADER_HEIGHT;
+      const gWidth = group.x1 - group.x0;
+      const gHeight = group.y1 - group.y0;
+
+      const groupNode = fileGroupLayer.append("g");
+
+      // Header strip carrying the file path.
+      groupNode
+        .append("rect")
+        .attr("x", gx)
+        .attr("y", gy)
+        .attr("width", gWidth)
+        .attr("height", this.FILE_HEADER_HEIGHT)
+        .attr("fill", this.COLORS.border)
+        .attr("fill-opacity", 0.12);
+
+      // Outline around the whole file group.
+      groupNode
+        .append("rect")
+        .attr("x", gx)
+        .attr("y", gy)
+        .attr("width", gWidth)
+        .attr("height", gHeight)
+        .attr("fill", "none")
+        .attr("stroke", this.COLORS.border)
+        .attr("stroke-width", 1.5);
+
+      // File path label, left-aligned in the header strip.
+      groupNode
+        .append("text")
+        .attr("x", gx + 6)
+        .attr("y", gy + this.FILE_HEADER_HEIGHT - 5)
+        .attr("text-anchor", "start")
+        .attr("font-family", "Arial, sans-serif")
+        .attr("font-size", "11px")
+        .attr("font-weight", "bold")
+        .attr("fill", this.COLORS.text)
+        .text(this.truncateText(groupData.file, gWidth - 12));
+    }
+
+    // Draw the function/file coverage tiles.
     const leaves = root.leaves();
     const leafGroup = svg.append("g").attr("class", "leaves");
 
     for (const leaf of leaves as HierarchyRectangularNode<
-      TreemapData | TreemapNode
+      TreemapData | TreemapFileGroup | TreemapNode
     >[]) {
       if (
         leaf.x0 === undefined ||
@@ -248,26 +347,30 @@ export class TreemapGenerator {
         .attr("stroke", this.COLORS.border)
         .attr("stroke-width", 1);
 
-      // Draw "ticker style" labels when the tile is large enough: the name
-      // sits at the top like a ticker symbol, with the coverage percentage as
-      // the headline figure in the middle and the line count beneath it.
+      // Draw "ticker style" labels when the tile is large enough: the function
+      // name sits at the top like a ticker symbol, with the coverage
+      // percentage as the headline figure in the middle and the line count
+      // beneath it. The file path is already on the group header above.
       if (width > 80 && height > 30) {
         const textGroup = nodeGroup.append("g");
         const centerX = x + width / 2;
         const ticker = this.formatTickerLines(node);
 
-        // Symbol (file/class/function name) pinned to the top.
-        textGroup
-          .append("text")
-          .attr("x", centerX)
-          .attr("y", y + 16)
-          .attr("text-anchor", "middle")
-          .attr("font-family", "Arial, sans-serif")
-          .attr("font-size", "12px")
-          .attr("font-weight", "bold")
-          .attr("letter-spacing", "0.5")
-          .attr("fill", this.COLORS.text)
-          .text(this.truncateText(ticker.name, width - 10));
+        let topOffset = 0;
+        if (ticker.name) {
+          topOffset = 16;
+          // Function name pinned to the top.
+          textGroup
+            .append("text")
+            .attr("x", centerX)
+            .attr("y", y + topOffset)
+            .attr("text-anchor", "middle")
+            .attr("font-family", "Arial, sans-serif")
+            .attr("font-size", "12px")
+            .attr("font-weight", "bold")
+            .attr("fill", this.COLORS.text)
+            .text(this.truncateText(ticker.name, width - 10));
+        }
 
         if (height > 50) {
           const centerY = y + height / 2;
@@ -378,14 +481,13 @@ export class TreemapGenerator {
   }
 
   /**
-   * Build the three "ticker style" text rows for a tile: the symbol (name) on
+   * Build the three "ticker style" text rows for a tile: the function name on
    * top, the coverage percentage as the headline figure in the middle, and the
    * covered/total line count underneath.
    *
-   * For function tiles the symbol is prefixed with the file basename
-   * (e.g. `example.ts › doWork`) so the same function name appearing in
-   * different files stays distinguishable. File-level tiles already carry the
-   * basename, so they are shown as-is.
+   * The name is the function name only; the owning file path is drawn once on
+   * the group header, so file-level tiles (without a function name) return an
+   * empty name and the renderer omits that row.
    */
   static formatTickerLines(node: TreemapNode): {
     name: string;
@@ -397,12 +499,8 @@ export class TreemapGenerator {
         ? Math.round((node.coveredLines / node.lineCount) * 100)
         : 0;
 
-    const name = node.functionName
-      ? `${path.basename(node.file)} › ${node.functionName}`
-      : path.basename(node.file);
-
     return {
-      name,
+      name: node.functionName ?? "",
       percent: `${percentValue}%`,
       lines: `${node.coveredLines}/${node.lineCount} lines`,
     };

--- a/src/treemapGenerator.ts
+++ b/src/treemapGenerator.ts
@@ -381,6 +381,11 @@ export class TreemapGenerator {
    * Build the three "ticker style" text rows for a tile: the symbol (name) on
    * top, the coverage percentage as the headline figure in the middle, and the
    * covered/total line count underneath.
+   *
+   * For function tiles the symbol is prefixed with the file basename
+   * (e.g. `example.ts › doWork`) so the same function name appearing in
+   * different files stays distinguishable. File-level tiles already carry the
+   * basename, so they are shown as-is.
    */
   static formatTickerLines(node: TreemapNode): {
     name: string;
@@ -392,8 +397,12 @@ export class TreemapGenerator {
         ? Math.round((node.coveredLines / node.lineCount) * 100)
         : 0;
 
+    const name = node.functionName
+      ? `${path.basename(node.file)} › ${node.functionName}`
+      : path.basename(node.file);
+
     return {
-      name: node.functionName || path.basename(node.file),
+      name,
       percent: `${percentValue}%`,
       lines: `${node.coveredLines}/${node.lineCount} lines`,
     };


### PR DESCRIPTION
## Summary

Improves the symbol shown at the top of each treemap tile.

Previously a function tile showed only the bare function name (e.g. `render`), which is ambiguous when the same name appears in multiple files. Class names are not available from LCOV — only `FN:` function-name records are parsed, so deriving a class would require unreliable per-language heuristics. The **file path is already on every node**, so prefixing the file basename is the simpler and more robust option.

- Function tiles now render as `basename › functionName` (e.g. `widget.ts › render`).
- File-level tiles are unchanged — they already carry the basename.
- The prefix uses the basename only (not the full path) to stay compact; existing tile truncation still applies.

## Testing

- Added unit tests asserting the `basename › name` format and that only the basename (not the full directory path) is used as the prefix.
- Considered the file-level fallback case (no `functionName`) which keeps showing the plain basename.