### PR TITLE
Add Marketplace release compliance docs and disclaimers

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,68 @@
+# Privacy Policy
+
+_Last updated: 2026-06-17_
+
+This privacy policy describes how the **Coverage Treemap Action**
+(`maxbirkner/coveragemap`, "the Action") handles data. The Action is a free,
+open-source hobby project maintained by Maximilian Birkner ("the Maintainer").
+
+## Summary
+
+**The Action does not collect, transmit, sell, or share your data with the
+Maintainer or any third party.** There is no telemetry, no analytics, and no
+external backend service. All processing happens inside your own GitHub Actions
+runner.
+
+## What the Action does with data
+
+When you run the Action in a workflow, it:
+
+1. Reads the LCOV coverage report you point it at (`lcov-file`) from the runner's
+   file system.
+2. Determines the files changed in the pull request using the local git
+   checkout.
+3. Generates a treemap image in memory on the runner.
+4. Uses the GitHub token / GitHub App credentials **that you supply** to:
+   - post or update a pull request comment,
+   - optionally upload an `annotations.json` workflow artifact, and
+   - optionally post check-run annotations via the GitHub Checks API.
+
+All of these interactions are made directly between **your** workflow runner and
+**your** GitHub repository, using **your** credentials. The Maintainer never
+receives any of this data.
+
+## Data the Maintainer collects
+
+**None.** The Action sends no data to the Maintainer or to any service operated
+by the Maintainer. It contains no analytics, tracking, or "phone-home"
+behaviour.
+
+## Controller and purpose limitation
+
+You (the user running the Action) remain the sole controller of any data the
+Action processes. The Maintainer does not act as a data processor or controller
+on your behalf and does not act on GitHub's behalf in collecting data. Any data
+processed by the Action is used solely to provide the Action's functionality and
+for no other purpose (it is never used for marketing or resold).
+
+## Credentials and secrets
+
+The Action consumes the `github-token` and optional GitHub App credentials you
+provide via workflow secrets. These are used only at runtime to authenticate
+calls to the GitHub API and are never logged or transmitted anywhere other than
+GitHub's own API endpoints.
+
+## Third-party services
+
+The Action calls only the GitHub API (`api.github.com` / your GitHub Enterprise
+host) using your credentials. It does not contact any other third-party service.
+
+## Changes to this policy
+
+This policy may be updated over time. Material changes will be reflected in this
+file and in the repository's release notes.
+
+## Contact
+
+Questions about privacy can be raised via
+[GitHub Issues](https://github.com/maxbirkner/coveragemap/issues).

--- a/README.md
+++ b/README.md
@@ -251,12 +251,12 @@ jobs:
         run: echo "base-depth=$(expr ${{ github.event.pull_request.commits }} + 1)" | tee -a $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
 
       - name: "Setup Node.js"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "18"
           cache: "npm"
@@ -268,9 +268,11 @@ jobs:
       - name: "Run tests and generate coverage"
         run: npm run test -- --no-watch --code-coverage
 
+      # Pinning to a full commit SHA (rather than a tag like @v1) is recommended
+      # for stronger supply-chain security. Find the SHA on the release page.
       - name: "Coverage Treemap Action"
         id: coverage_check
-        uses: your-username/coverage-treemap-action@v1
+        uses: maxbirkner/coveragemap@v1
         with:
           lcov-file: "./coverage/your-project-name/lcov.info"
           coverage-threshold: 85
@@ -293,7 +295,7 @@ If you need to run multiple coverage checks (e.g., for different test suites), u
 ```yaml
       # Frontend coverage check
       - name: "Frontend Coverage Check"
-        uses: your-username/coverage-treemap-action@v1
+        uses: maxbirkner/coveragemap@v1
         with:
           lcov-file: "./coverage/frontend/lcov.info"
           coverage-threshold: 80
@@ -302,7 +304,7 @@ If you need to run multiple coverage checks (e.g., for different test suites), u
 
       # Backend coverage check
       - name: "Backend Coverage Check"
-        uses: your-username/coverage-treemap-action@v1
+        uses: maxbirkner/coveragemap@v1
         with:
           lcov-file: "./coverage/backend/lcov.info"
           coverage-threshold: 85
@@ -316,10 +318,41 @@ For projects where you want to ensure new code maintains or improves the overall
 
 ```yaml
       - name: "Coverage Baseline Check"
-        uses: your-username/coverage-treemap-action@v1
+        uses: maxbirkner/coveragemap@v1
         with:
           lcov-file: "./coverage/lcov.info"
           coverage-threshold: "0"  # Compare against project average
           github-token: ${{ secrets.GITHUB_TOKEN }}
           label: "Quality Gate"
 ```
+
+## Privacy
+
+This action runs entirely inside your own GitHub Actions runner. It does not
+collect, transmit, or share your data with the maintainer or any third party,
+and it contains no telemetry or analytics. See [PRIVACY.md](PRIVACY.md) for
+details.
+
+## Support
+
+This is a free, open-source hobby project. Please report bugs and ask questions
+via [GitHub Issues](https://github.com/maxbirkner/coveragemap/issues). See
+[SUPPORT.md](SUPPORT.md) for what to include. For security reports, see
+[SECURITY.md](SECURITY.md).
+
+## Disclaimer
+
+This software is provided **"AS IS"**, without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability, fitness
+for a particular purpose, and noninfringement. In no event shall the authors or
+copyright holders be liable for any claim, damages, or other liability, whether
+in an action of contract, tort, or otherwise, arising from, out of, or in
+connection with the software or the use or other dealings in the software.
+
+You are responsible for reviewing the action and pinning it to a specific
+version or commit SHA before using it in your workflows. See the
+[LICENSE](LICENSE) file for the full terms.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in the Coverage Treemap Action, please
+report it privately using GitHub's
+[private vulnerability reporting](https://github.com/maxbirkner/coveragemap/security/advisories/new)
+for this repository. Please do not open a public issue for security problems.
+
+Include enough detail to reproduce the issue. As this is a hobby project
+maintained in spare time, please allow a reasonable amount of time for a
+response and a fix before any public disclosure.
+
+## Supply-chain and dependency hygiene
+
+To reduce the risk of malicious or "silent" upstream changes:
+
+  - **The published action is a committed, self-contained bundle.** The runtime
+  entry point (`dist/index.js`) is built with esbuild and committed to the
+  repository, and CI verifies it is in sync with the source. Consumers run
+  exactly the reviewed bundle rather than resolving dependencies at runtime.
+  - **Workflow actions are pinned to full commit SHAs**, not floating tags, in
+  this repository's own workflows.
+  - **Runtime dependency versions are locked** via `package-lock.json`, and
+  updates are reviewed (Renovate is used to surface them).
+  - Consumers are encouraged to pin this action to a full commit SHA in their own
+  workflows (see the README usage examples).
+
+## Scope and disclaimer
+
+The action is provided "AS IS", without warranty of any kind. See the
+[README](README.md#disclaimer) and [LICENSE](LICENSE) for the full disclaimer.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# Support
+
+The Coverage Treemap Action is a free, open-source hobby project. Support is
+provided on a best-effort basis by the maintainer and the community.
+
+## Getting help
+
+  - **Bugs and unexpected behaviour:** Please open a
+  [GitHub Issue](https://github.com/maxbirkner/coveragemap/issues). Include the
+  action version, a minimal workflow snippet, and the relevant log output.
+  - **Questions and ideas:** Use
+  [GitHub Issues](https://github.com/maxbirkner/coveragemap/issues) as well —
+  there is no separate support desk or paid support tier.
+
+## Before opening an issue
+
+1. Check the [README](README.md) for configuration and usage details.
+2. Search [existing issues](https://github.com/maxbirkner/coveragemap/issues) to
+   see whether your problem has already been reported.
+
+## Response expectations
+
+This is a hobby project maintained in spare time, so responses may take a while.
+Reproducible reports with clear logs are the most likely to be addressed
+quickly.
+
+## Security issues
+
+Please do **not** report security vulnerabilities in public issues. See
+[SECURITY.md](SECURITY.md) for how to report them responsibly.


### PR DESCRIPTION
Prepares the action for GitHub Marketplace publication by addressing the "quiet" obligations of the Marketplace Developer Agreement for a free, open-source hobby project (no paid tier, no companion SaaS).

## What changed

- **PRIVACY.md** — Privacy policy stating the action runs entirely inside the user's own runner, collects/transmits no data to the maintainer or third parties, has no telemetry/analytics, and that the user remains the sole data controller (purpose limitation, no reselling/marketing). Addresses Addendum 1 concerns.
- **SUPPORT.md** — Documents GitHub Issues as the support channel and sets best-effort response expectations (Section 5.3 "you support your developer product").
- **SECURITY.md** — Private vulnerability reporting plus supply-chain hygiene notes: committed self-contained `dist/` bundle, SHA-pinned workflow actions, locked runtime deps (Section 3.3).
- **README.md** — Added prominent "AS IS" disclaimer, plus Privacy/Support/Security/License sections; replaced placeholder `your-username/coverage-treemap-action@v1` with the real `maxbirkner/coveragemap@v1`, SHA-pinned the helper actions in the example, and added a note recommending consumers pin to a commit SHA.

## Notes

- Documentation-only change. No source or `dist/` bundle changes, so no rebuild required.
- The Marketplace listing's Privacy Policy URL field should point at PRIVACY.md when publishing.

## Testing

- `pre-commit run --files PRIVACY.md SUPPORT.md SECURITY.md README.md` passes (markdownlint, prettier, codespell, end-of-file-fixer, etc.).
- Manually reviewed rendered Markdown for the new sections and the corrected example workflow.