### PR TITLE
Shorten action description below Marketplace 125-character limit

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,7 +1,5 @@
 name: Coverage Map Action
-description: |
-  A GitHub Action that analyzes code coverage for files changed in a pull request,
-  generates a visual treemap of test gaps, and enforces a coverage threshold.
+description: Analyzes coverage for files changed in a PR, renders a treemap of test gaps, and enforces a coverage threshold.
 author: maxbirkner
 branding:
   icon: bar-chart-2


### PR DESCRIPTION
GitHub Marketplace rejects the release with "Description must be less than 125 characters." The listing derives its short description from `action.yaml`'s `description` field, which was a ~150-character multi-line block.

## What changed

- Collapsed the `description` in `action.yaml` to a single line of **111 characters**, still conveying the core function (analyze changed-file coverage, render a treemap, enforce a threshold).

## Testing

- `pre-commit run --files action.yaml` passes (yamllint, yamlfmt, prettier, etc.).
- Verified the description length is 111 characters (< 125).