### PR TITLE
Add minimum tile size and label wrapping to the treemap

### DIFF
--- a/src/treemapGenerator.render.test.ts
+++ b/src/treemapGenerator.render.test.ts
@@ -183,4 +183,135 @@ describe("TreemapGenerator rendering", () => {
       expect.any(Buffer),
     );
   });
+
+  it("grows the canvas so small tiles clear a minimum readable size", async () => {
+    // Many single-line functions would each render below the readable minimum
+    // at the default 1200x800 canvas, so the generator should scale the whole
+    // image up uniformly.
+    const functions = Array.from({ length: 160 }, (_, i) => ({
+      name: `fn${i}`,
+      line: i + 1,
+      hit: i % 2,
+    }));
+    const lines = Array.from({ length: 160 }, (_, i) => ({
+      line: i + 1,
+      hit: i % 2,
+    }));
+
+    const analysis: CoverageAnalysis = {
+      changeset: {
+        baseCommit: "abc123",
+        headCommit: "def456",
+        targetBranch: "main",
+        files: [],
+        totalFiles: 1,
+      },
+      changedFiles: [fileWithFunctions("src/many.ts", functions, lines)],
+      summary: {
+        totalChangedFiles: 1,
+        filesWithCoverage: 1,
+        filesWithoutCoverage: 0,
+        overallCoverage: {
+          totalLines: 160,
+          coveredLines: 80,
+          totalFunctions: 160,
+          coveredFunctions: 80,
+          totalBranches: 0,
+          coveredBranches: 0,
+          linesCoveragePercentage: 50,
+          functionsCoveragePercentage: 50,
+          branchesCoveragePercentage: 0,
+          overallCoveragePercentage: 50,
+        },
+      },
+    };
+
+    await TreemapGenerator.generatePNG(analysis, {
+      title: "Coverage Treemap",
+      outputPath: "./out.png",
+      width: 1200,
+      height: 800,
+    });
+
+    const svg = mockedRasterise.mock.calls[0][0];
+    const width = Number(/<svg[^>]*\bwidth="(\d+)"/.exec(svg)?.[1]);
+    const height = Number(/<svg[^>]*\bheight="(\d+)"/.exec(svg)?.[1]);
+
+    // The canvas grew past the requested size to give every tile room.
+    expect(width).toBeGreaterThan(1200);
+    expect(height).toBeGreaterThan(800);
+
+    // Every drawn tile clears the minimum tile width. Scope the search to the
+    // leaves layer so legend swatches and group outlines are excluded.
+    const leavesLayer = /<g class="leaves">([\s\S]*)<\/g><\/svg>/.exec(
+      svg,
+    )?.[1];
+    expect(leavesLayer).toBeDefined();
+    const tileWidths = Array.from(
+      (leavesLayer as string).matchAll(/<rect[^>]*\bwidth="([\d.]+)"/g),
+      (match) => Number(match[1]),
+    );
+    const smallestTile = Math.min(...tileWidths);
+    expect(smallestTile).toBeGreaterThanOrEqual(90);
+  });
+
+  it("wraps long function names instead of clipping them off", async () => {
+    const longName =
+      "renderTheEntireUserAuthenticationAndAuthorizationWorkflowForEnterpriseCustomers";
+
+    const analysis: CoverageAnalysis = {
+      changeset: {
+        baseCommit: "abc123",
+        headCommit: "def456",
+        targetBranch: "main",
+        files: [],
+        totalFiles: 1,
+      },
+      changedFiles: [
+        fileWithFunctions(
+          "src/wrap.ts",
+          // Sixteen equal-sized functions keep every tile narrow enough that
+          // the long name cannot fit on one line.
+          Array.from({ length: 16 }, (_, i) => ({
+            name: i === 0 ? longName : `helper${i}`,
+            line: i + 1,
+            hit: i % 2,
+          })),
+          Array.from({ length: 16 }, (_, i) => ({
+            line: i + 1,
+            hit: i % 2,
+          })),
+        ),
+      ],
+      summary: {
+        totalChangedFiles: 1,
+        filesWithCoverage: 1,
+        filesWithoutCoverage: 0,
+        overallCoverage: {
+          totalLines: 16,
+          coveredLines: 8,
+          totalFunctions: 16,
+          coveredFunctions: 8,
+          totalBranches: 0,
+          coveredBranches: 0,
+          linesCoveragePercentage: 50,
+          functionsCoveragePercentage: 50,
+          branchesCoveragePercentage: 0,
+          overallCoveragePercentage: 50,
+        },
+      },
+    };
+
+    await TreemapGenerator.generatePNG(analysis, {
+      title: "Coverage Treemap",
+      outputPath: "./out.png",
+    });
+
+    const svg = mockedRasterise.mock.calls[0][0];
+
+    // The name is too long for a single tile line, so it is never drawn whole.
+    expect(svg).not.toContain(longName);
+    // But it is not dropped either: an early fragment is still rendered.
+    expect(svg).toContain("render");
+  });
 });

--- a/src/treemapGenerator.test.ts
+++ b/src/treemapGenerator.test.ts
@@ -142,6 +142,62 @@ describe("TreemapGenerator", () => {
     });
   });
 
+  describe("wrapText", () => {
+    const PIXELS_PER_CHAR = 7;
+
+    it("returns the text unchanged when it already fits", () => {
+      expect(TreemapGenerator.wrapText("doWork", 200, 2)).toEqual(["doWork"]);
+    });
+
+    it("wraps a long camelCase name onto multiple lines that each fit", () => {
+      const maxWidth = 70; // ~10 characters per line
+      const lines = TreemapGenerator.wrapText(
+        "handleUserAuthentication",
+        maxWidth,
+        3,
+      );
+
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines) {
+        expect(line.length).toBeLessThanOrEqual(
+          Math.floor(maxWidth / PIXELS_PER_CHAR),
+        );
+      }
+      // The whole name is preserved across the lines (no characters dropped).
+      expect(lines.join("")).toBe("handleUserAuthentication");
+    });
+
+    it("breaks file paths on separators", () => {
+      const lines = TreemapGenerator.wrapText(
+        "src/deep/nested/widget.ts",
+        70,
+        4,
+      );
+
+      expect(lines.length).toBeGreaterThan(1);
+      expect(lines.join("")).toBe("src/deep/nested/widget.ts");
+    });
+
+    it("hard-splits unbreakable tokens with no natural boundaries", () => {
+      const maxWidth = 70; // 10 characters per line
+      const lines = TreemapGenerator.wrapText("a".repeat(25), maxWidth, 5);
+
+      for (const line of lines) {
+        expect(line.length).toBeLessThanOrEqual(10);
+      }
+      expect(lines.join("")).toBe("a".repeat(25));
+    });
+
+    it("ends the final line with an ellipsis once the content exceeds maxLines", () => {
+      const lines = TreemapGenerator.wrapText("a".repeat(60), 70, 2);
+
+      expect(lines).toHaveLength(2);
+      expect(lines[1].endsWith("...")).toBe(true);
+      // The cut-off line never exceeds the available width.
+      expect(lines[1].length).toBeLessThanOrEqual(10);
+    });
+  });
+
   describe("generateTreemapData", () => {
     it("should generate treemap data for files with coverage", () => {
       const mockAnalysis: CoverageAnalysis = {

--- a/src/treemapGenerator.ts
+++ b/src/treemapGenerator.ts
@@ -68,6 +68,25 @@ export class TreemapGenerator {
   private static readonly MIN_FUNCTION_SIZE_ESTIMATE = 10;
   private static readonly DEFAULT_FUNCTION_LINE_COUNT = 10;
 
+  // Smallest tile the layout is allowed to produce. When the proportional
+  // treemap would draw a tile below these bounds, the whole canvas is scaled
+  // up uniformly so every label has room to breathe. Readers can zoom into the
+  // larger image rather than squint at unreadable thumbnails.
+  private static readonly MIN_TILE_WIDTH = 96;
+  private static readonly MIN_TILE_HEIGHT = 56;
+
+  // Upper bound for the auto-grown canvas. Past this point we accept that some
+  // tiles stay small ("too much to render") instead of emitting an enormous
+  // image that no viewer can open.
+  private static readonly MAX_CANVAS_WIDTH = 5000;
+  private static readonly MAX_CANVAS_HEIGHT = 4000;
+
+  // Line heights used when stacking wrapped labels inside a tile.
+  private static readonly TILE_NAME_LINE_HEIGHT = 14;
+  private static readonly TILE_PERCENT_HEIGHT = 24;
+  private static readonly TILE_LINES_HEIGHT = 14;
+  private static readonly MAX_TILE_NAME_LINES = 2;
+
   // Vertical space reserved at the top for the title, subtitle and legend so
   // none of them overlap the coverage tiles below.
   private static readonly HEADER_HEIGHT = 70;
@@ -193,39 +212,58 @@ export class TreemapGenerator {
     // document/window patching is required.
     const { document } = parseHTML(`<!DOCTYPE html><html><body></body></html>`);
 
-    // Create SVG element
-    const svg = d3
-      .select(document.body)
-      .append("svg")
-      .attr("width", opts.width)
-      .attr("height", opts.height)
-      .attr("xmlns", "http://www.w3.org/2000/svg");
-
-    // Add background
-    svg
-      .append("rect")
-      .attr("width", opts.width)
-      .attr("height", opts.height)
-      .attr("fill", this.COLORS.background);
-
     // Create D3 treemap layout
     const root = hierarchy<TreemapData | TreemapFileGroup | TreemapNode>(data)
       .sum((d) => (d as TreemapNode).value || 0)
       .sort((a, b) => (b.value || 0) - (a.value || 0));
 
-    const treemapLayout = treemap<
-      TreemapData | TreemapFileGroup | TreemapNode
-    >()
-      .size([
-        opts.width - this.SIDE_MARGIN * 2,
-        opts.height - (this.HEADER_HEIGHT + this.BOTTOM_MARGIN),
-      ])
-      .paddingOuter(2)
-      // Reserve a header band on each file group for its path label.
-      .paddingTop((d) => (d.depth === 1 ? this.FILE_HEADER_HEIGHT : 2))
-      .paddingInner(2);
+    // Lay the tiles out for a given drawable area (excluding the title header
+    // band and the page margins). The layout mutates `root` in place.
+    const layoutInto = (innerWidth: number, innerHeight: number) => {
+      treemap<TreemapData | TreemapFileGroup | TreemapNode>()
+        .size([innerWidth, innerHeight])
+        .paddingOuter(2)
+        // Reserve a header band on each file group for its path label.
+        .paddingTop((d) => (d.depth === 1 ? this.FILE_HEADER_HEIGHT : 2))
+        .paddingInner(2)(root);
+    };
 
-    treemapLayout(root);
+    const baseInnerWidth = opts.width - this.SIDE_MARGIN * 2;
+    const baseInnerHeight =
+      opts.height - (this.HEADER_HEIGHT + this.BOTTOM_MARGIN);
+
+    // Lay out once at the requested size, then grow the canvas uniformly if the
+    // smallest tile would be too cramped to read. Scaling both dimensions by
+    // the same factor keeps the squarified layout identical, just larger.
+    layoutInto(baseInnerWidth, baseInnerHeight);
+    const scale = this.scaleForMinimumTileSize(
+      root.leaves() as HierarchyRectangularNode<
+        TreemapData | TreemapFileGroup | TreemapNode
+      >[],
+      opts.width,
+      opts.height,
+    );
+
+    const canvasWidth = Math.round(opts.width * scale);
+    const canvasHeight = Math.round(opts.height * scale);
+    if (scale > 1) {
+      layoutInto(baseInnerWidth * scale, baseInnerHeight * scale);
+    }
+
+    // Create SVG element
+    const svg = d3
+      .select(document.body)
+      .append("svg")
+      .attr("width", canvasWidth)
+      .attr("height", canvasHeight)
+      .attr("xmlns", "http://www.w3.org/2000/svg");
+
+    // Add background
+    svg
+      .append("rect")
+      .attr("width", canvasWidth)
+      .attr("height", canvasHeight)
+      .attr("fill", this.COLORS.background);
 
     // Draw title (left-aligned in the reserved header band)
     svg
@@ -253,7 +291,7 @@ export class TreemapGenerator {
 
     // Draw the legend on the same line as the title, aligned to the right
     // edge. It lives in the reserved header band so it never overlaps tiles.
-    this.drawSVGLegend(svg, opts.width - this.SIDE_MARGIN, 35);
+    this.drawSVGLegend(svg, canvasWidth - this.SIDE_MARGIN, 35);
 
     // Draw a labelled box around each file's functions. The file path lives on
     // this header once, so the function tiles below only show the function
@@ -348,59 +386,11 @@ export class TreemapGenerator {
         .attr("stroke-width", 1);
 
       // Draw "ticker style" labels when the tile is large enough: the function
-      // name sits at the top like a ticker symbol, with the coverage
-      // percentage as the headline figure in the middle and the line count
-      // beneath it. The file path is already on the group header above.
-      if (width > 80 && height > 30) {
-        const textGroup = nodeGroup.append("g");
-        const centerX = x + width / 2;
-        const ticker = this.formatTickerLines(node);
-
-        let topOffset = 0;
-        if (ticker.name) {
-          topOffset = 16;
-          // Function name pinned to the top.
-          textGroup
-            .append("text")
-            .attr("x", centerX)
-            .attr("y", y + topOffset)
-            .attr("text-anchor", "middle")
-            .attr("font-family", "Arial, sans-serif")
-            .attr("font-size", "12px")
-            .attr("font-weight", "bold")
-            .attr("fill", this.COLORS.text)
-            .text(this.truncateText(ticker.name, width - 10));
-        }
-
-        if (height > 50) {
-          const centerY = y + height / 2;
-
-          // Headline percentage, centred like a ticker quote.
-          textGroup
-            .append("text")
-            .attr("x", centerX)
-            .attr("y", centerY + 4)
-            .attr("text-anchor", "middle")
-            .attr("font-family", "Arial, sans-serif")
-            .attr("font-size", "22px")
-            .attr("font-weight", "bold")
-            .attr("fill", this.COLORS.text)
-            .text(ticker.percent);
-
-          if (height > 70) {
-            // Covered/total line count just below the headline figure.
-            textGroup
-              .append("text")
-              .attr("x", centerX)
-              .attr("y", centerY + 22)
-              .attr("text-anchor", "middle")
-              .attr("font-family", "Arial, sans-serif")
-              .attr("font-size", "11px")
-              .attr("fill", this.COLORS.text)
-              .text(this.truncateText(ticker.lines, width - 10));
-          }
-        }
-      }
+      // name sits on top like a ticker symbol, the coverage percentage is the
+      // headline figure, and the line count sits beneath it. Long names wrap
+      // onto multiple lines instead of being clipped. The file path is already
+      // on the group header above.
+      this.drawTileLabels(nodeGroup, node, x, y, width, height);
     }
 
     // Convert SVG to string
@@ -476,6 +466,204 @@ export class TreemapGenerator {
    */
   static colorForCoverage(coverage: TreemapNode["coverage"]): string {
     return this.COLORS[coverage] ?? this.COLORS.none;
+  }
+
+  /**
+   * Determine how much the canvas must grow so the smallest tile clears the
+   * minimum readable size. Both dimensions are scaled by the same factor, which
+   * keeps the squarified layout identical while enlarging every tile. The
+   * factor is capped so pathological inputs cannot produce an unopenable image.
+   */
+  private static scaleForMinimumTileSize(
+    leaves: HierarchyRectangularNode<
+      TreemapData | TreemapFileGroup | TreemapNode
+    >[],
+    width: number,
+    height: number,
+  ): number {
+    let scale = 1;
+    for (const leaf of leaves) {
+      if (
+        leaf.x0 === undefined ||
+        leaf.y0 === undefined ||
+        leaf.x1 === undefined ||
+        leaf.y1 === undefined
+      )
+        continue;
+
+      const tileWidth = leaf.x1 - leaf.x0;
+      const tileHeight = leaf.y1 - leaf.y0;
+      if (tileWidth <= 0 || tileHeight <= 0) continue;
+
+      scale = Math.max(
+        scale,
+        this.MIN_TILE_WIDTH / tileWidth,
+        this.MIN_TILE_HEIGHT / tileHeight,
+      );
+    }
+
+    const maxScale = Math.max(
+      1,
+      Math.min(this.MAX_CANVAS_WIDTH / width, this.MAX_CANVAS_HEIGHT / height),
+    );
+    return Math.min(scale, maxScale);
+  }
+
+  /**
+   * Draw the centred "ticker style" labels inside a tile: the (wrapped)
+   * function name, the headline coverage percentage and the covered/total line
+   * count. Rows are revealed progressively so a short tile still shows its
+   * headline figure, and the whole stack is vertically centred.
+   */
+  private static drawTileLabels(
+    parent: d3.Selection<SVGGElement, unknown, null, undefined>,
+    node: TreemapNode,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ): void {
+    // Below this the tile cannot host even a single readable figure.
+    if (width < 60 || height < 28) return;
+
+    const ticker = this.formatTickerLines(node);
+    const centerX = x + width / 2;
+
+    const nameLines = ticker.name
+      ? this.wrapText(ticker.name, width - 10, this.MAX_TILE_NAME_LINES)
+      : [];
+    const nameBlock = nameLines.length * this.TILE_NAME_LINE_HEIGHT;
+
+    const showName =
+      nameLines.length > 0 &&
+      height >= nameBlock + this.TILE_PERCENT_HEIGHT + 8;
+    const showLines =
+      height >=
+      (showName ? nameBlock : 0) +
+        this.TILE_PERCENT_HEIGHT +
+        this.TILE_LINES_HEIGHT +
+        8;
+
+    let stackHeight = this.TILE_PERCENT_HEIGHT;
+    if (showName) stackHeight += nameBlock;
+    if (showLines) stackHeight += this.TILE_LINES_HEIGHT;
+
+    const textGroup = parent.append("g");
+    const drawRow = (
+      text: string,
+      baselineY: number,
+      fontSize: number,
+      bold: boolean,
+    ): void => {
+      const element = textGroup
+        .append("text")
+        .attr("x", centerX)
+        .attr("y", baselineY)
+        .attr("text-anchor", "middle")
+        .attr("font-family", "Arial, sans-serif")
+        .attr("font-size", `${fontSize}px`)
+        .attr("fill", this.COLORS.text);
+      if (bold) element.attr("font-weight", "bold");
+      element.text(text);
+    };
+
+    let top = y + (height - stackHeight) / 2;
+
+    if (showName) {
+      nameLines.forEach((line, index) => {
+        drawRow(line, top + index * this.TILE_NAME_LINE_HEIGHT + 11, 12, true);
+      });
+      top += nameBlock;
+    }
+
+    drawRow(ticker.percent, top + 18, 22, true);
+    top += this.TILE_PERCENT_HEIGHT;
+
+    if (showLines) {
+      drawRow(ticker.lines, top + 11, 11, false);
+    }
+  }
+
+  /**
+   * Wrap text onto at most `maxLines` lines, each fitting within `maxWidth`.
+   * Breaks prefer natural boundaries (path separators, dots, camelCase) and
+   * fall back to hard character splits for unbreakable tokens. When the content
+   * still overflows `maxLines`, the final line ends with an ellipsis — this is
+   * the "too much text to render" cut-off.
+   */
+  static wrapText(text: string, maxWidth: number, maxLines: number): string[] {
+    const maxChars = Math.max(1, Math.floor(maxWidth / this.PIXELS_PER_CHAR));
+    if (text.length <= maxChars) return [text];
+
+    const segments = this.segmentText(text).flatMap((segment) =>
+      segment.length <= maxChars
+        ? [segment]
+        : this.hardSplit(segment, maxChars),
+    );
+
+    const lines: string[] = [];
+    let line = "";
+    for (const segment of segments) {
+      if (line.length > 0 && line.length + segment.length > maxChars) {
+        lines.push(line);
+        line = segment;
+      } else {
+        line += segment;
+      }
+    }
+    if (line.length > 0) lines.push(line);
+
+    if (lines.length <= maxLines) return lines;
+
+    const kept = lines.slice(0, maxLines);
+    const lastIndex = maxLines - 1;
+    const last = kept[lastIndex] ?? "";
+    const room = Math.max(0, maxChars - this.ELLIPSIS_LENGTH);
+    kept[lastIndex] =
+      (last.length > room ? last.substring(0, room) : last) + "...";
+    return kept;
+  }
+
+  /**
+   * Split text into break-friendly segments. A segment ends after a separator
+   * (`/`, `.`, `_`, `-`, space) or before a camelCase hump, so wrapping favours
+   * readable boundaries within identifiers and file paths.
+   */
+  private static segmentText(text: string): string[] {
+    const segments: string[] = [];
+    let current = "";
+    for (let index = 0; index < text.length; index++) {
+      const char = text[index] as string;
+      const next = text[index + 1];
+      current += char;
+
+      const isSeparator =
+        char === "/" ||
+        char === "." ||
+        char === "_" ||
+        char === "-" ||
+        char === " ";
+      const isCamelBoundary =
+        next !== undefined && /[a-z0-9]/.test(char) && /[A-Z]/.test(next);
+
+      if (isSeparator || isCamelBoundary) {
+        segments.push(current);
+        current = "";
+      }
+    }
+    if (current.length > 0) segments.push(current);
+    return segments;
+  }
+
+  /**
+   * Hard-split an unbreakable token into chunks of at most `maxChars`.
+   */
+  private static hardSplit(text: string, maxChars: number): string[] {
+    const chunks: string[] = [];
+    for (let index = 0; index < text.length; index += maxChars) {
+      chunks.push(text.substring(index, index + maxChars));
+    }
+    return chunks;
   }
 
   /**


### PR DESCRIPTION
## Summary

Coverage tiles could shrink to unreadable slivers, and long function names were
silently clipped. This change makes the treemap render legibly regardless of how
many functions a file has or how long their names are:

- **Minimum tile size with canvas auto-scaling.** After the proportional layout
  runs, the smallest tile is measured; if it falls below a readable minimum the
  whole canvas is scaled up uniformly (preserving the layout) so every tile has
  room. Scaling is capped at a maximum canvas size so pathological inputs can't
  produce an unopenable image — past that point some tiles stay small, the
  "too much to render" cut-off. Larger SVGs are preferred so readers can zoom in.
- **Label wrapping.** Function names now wrap onto multiple lines, breaking on
  natural boundaries (path separators, dots, camelCase humps) and hard-splitting
  unbreakable tokens. When the text still overflows the allotted lines, the final
  line ends with an ellipsis. Tile rows (name / percentage / line count) are
  revealed progressively and the stack is vertically centred.

## Testing

In addition to the unit and render tests added here (which run in CI), I rendered
real PNGs through the actual d3 + linkedom + resvg pipeline and visually inspected
them across three scenarios: a realistic mixed file, ~120 tiny single-line
functions (confirming the canvas grows and every tile stays readable), and a file
full of long names (confirming names wrap onto two lines and ellipsise when they
still don't fit). Temporary render artifacts were removed before committing.
