### PR TITLE
Refactor coverage analyzer and gating to remove duplicated percentage math

### DIFF
--- a/src/coverageAnalyzer.ts
+++ b/src/coverageAnalyzer.ts
@@ -1,5 +1,10 @@
 import { Changeset, FileChange } from "./changeset";
-import { LcovReport, FileCoverage, FunctionCoverage } from "./lcov";
+import {
+  LcovReport,
+  FileCoverage,
+  FunctionCoverage,
+  CoverageCounts,
+} from "./lcov";
 
 export interface FileChangeWithCoverage extends FileChange {
   coverage?: FileCoverage;
@@ -48,6 +53,36 @@ export class CoverageAnalyzer {
   // as 0% in the totals — is misleading. We normalize them to empty coverage.
   private static readonly EMPTY_REPORT_FUNCTION_NAME = "(empty-report)";
 
+  // Distinct from calculateFileAnalysis's 100% for empty-but-coverable
+  // metrics: a file with no coverage data at all reports 0% across the board.
+  private static readonly EMPTY_FILE_ANALYSIS: FileChangeWithCoverage["analysis"] =
+    {
+      totalLines: 0,
+      coveredLines: 0,
+      totalFunctions: 0,
+      coveredFunctions: 0,
+      totalBranches: 0,
+      coveredBranches: 0,
+      linesCoveragePercentage: 0,
+      functionsCoveragePercentage: 0,
+      branchesCoveragePercentage: 0,
+      overallCoveragePercentage: 0,
+    };
+
+  private static percentage(hit: number, found: number): number {
+    return found > 0 ? (hit / found) * 100 : 100;
+  }
+
+  private static round2(value: number): number {
+    return Math.round(value * 100) / 100;
+  }
+
+  private static withCoverage(
+    file: FileChangeWithCoverage,
+  ): file is FileChangeWithCoverage & { coverage: FileCoverage } {
+    return !!file.coverage;
+  }
+
   /**
    * Analyze coverage for the changed files in a changeset
    */
@@ -72,18 +107,7 @@ export class CoverageAnalyzer {
           // File has no coverage data (e.g., not instrumented or no tests)
           return {
             ...fileChange,
-            analysis: {
-              totalLines: 0,
-              coveredLines: 0,
-              totalFunctions: 0,
-              coveredFunctions: 0,
-              totalBranches: 0,
-              coveredBranches: 0,
-              linesCoveragePercentage: 0,
-              functionsCoveragePercentage: 0,
-              branchesCoveragePercentage: 0,
-              overallCoveragePercentage: 0,
-            },
+            analysis: { ...this.EMPTY_FILE_ANALYSIS },
           };
         }
       },
@@ -128,50 +152,44 @@ export class CoverageAnalyzer {
   }
 
   /**
+   * Build a rounded analysis object from aggregate found/hit counts. Overall
+   * coverage is the weighted average across all lines, functions and branches.
+   */
+  private static analysisFromCounts(
+    counts: CoverageCounts,
+  ): FileChangeWithCoverage["analysis"] {
+    const totalElements =
+      counts.linesFound + counts.functionsFound + counts.branchesFound;
+    const coveredElements =
+      counts.linesHit + counts.functionsHit + counts.branchesHit;
+
+    return {
+      totalLines: counts.linesFound,
+      coveredLines: counts.linesHit,
+      totalFunctions: counts.functionsFound,
+      coveredFunctions: counts.functionsHit,
+      totalBranches: counts.branchesFound,
+      coveredBranches: counts.branchesHit,
+      linesCoveragePercentage: this.round2(
+        this.percentage(counts.linesHit, counts.linesFound),
+      ),
+      functionsCoveragePercentage: this.round2(
+        this.percentage(counts.functionsHit, counts.functionsFound),
+      ),
+      branchesCoveragePercentage: this.round2(
+        this.percentage(counts.branchesHit, counts.branchesFound),
+      ),
+      overallCoveragePercentage: this.round2(
+        this.percentage(coveredElements, totalElements),
+      ),
+    };
+  }
+
+  /**
    * Calculate coverage analysis for a single file
    */
   private static calculateFileAnalysis(coverage: FileCoverage) {
-    const { summary } = coverage;
-
-    const linesCoveragePercentage =
-      summary.linesFound > 0
-        ? (summary.linesHit / summary.linesFound) * 100
-        : 100;
-
-    const functionsCoveragePercentage =
-      summary.functionsFound > 0
-        ? (summary.functionsHit / summary.functionsFound) * 100
-        : 100;
-
-    const branchesCoveragePercentage =
-      summary.branchesFound > 0
-        ? (summary.branchesHit / summary.branchesFound) * 100
-        : 100;
-
-    // Calculate overall coverage as weighted average
-    const totalElements =
-      summary.linesFound + summary.functionsFound + summary.branchesFound;
-    const coveredElements =
-      summary.linesHit + summary.functionsHit + summary.branchesHit;
-
-    const overallCoveragePercentage =
-      totalElements > 0 ? (coveredElements / totalElements) * 100 : 100;
-
-    return {
-      totalLines: summary.linesFound,
-      coveredLines: summary.linesHit,
-      totalFunctions: summary.functionsFound,
-      coveredFunctions: summary.functionsHit,
-      totalBranches: summary.branchesFound,
-      coveredBranches: summary.branchesHit,
-      linesCoveragePercentage: Math.round(linesCoveragePercentage * 100) / 100,
-      functionsCoveragePercentage:
-        Math.round(functionsCoveragePercentage * 100) / 100,
-      branchesCoveragePercentage:
-        Math.round(branchesCoveragePercentage * 100) / 100,
-      overallCoveragePercentage:
-        Math.round(overallCoveragePercentage * 100) / 100,
-    };
+    return this.analysisFromCounts(coverage.summary);
   }
 
   /**
@@ -181,58 +199,29 @@ export class CoverageAnalyzer {
     const filesWithCoverage = changedFiles.filter((f) => f.coverage).length;
     const filesWithoutCoverage = changedFiles.length - filesWithCoverage;
 
-    // Aggregate coverage data
-    let totalLines = 0;
-    let coveredLines = 0;
-    let totalFunctions = 0;
-    let coveredFunctions = 0;
-    let totalBranches = 0;
-    let coveredBranches = 0;
+    const aggregate: CoverageCounts = {
+      linesFound: 0,
+      linesHit: 0,
+      functionsFound: 0,
+      functionsHit: 0,
+      branchesFound: 0,
+      branchesHit: 0,
+    };
 
     for (const file of changedFiles) {
-      totalLines += file.analysis.totalLines;
-      coveredLines += file.analysis.coveredLines;
-      totalFunctions += file.analysis.totalFunctions;
-      coveredFunctions += file.analysis.coveredFunctions;
-      totalBranches += file.analysis.totalBranches;
-      coveredBranches += file.analysis.coveredBranches;
+      aggregate.linesFound += file.analysis.totalLines;
+      aggregate.linesHit += file.analysis.coveredLines;
+      aggregate.functionsFound += file.analysis.totalFunctions;
+      aggregate.functionsHit += file.analysis.coveredFunctions;
+      aggregate.branchesFound += file.analysis.totalBranches;
+      aggregate.branchesHit += file.analysis.coveredBranches;
     }
-
-    const linesCoveragePercentage =
-      totalLines > 0 ? (coveredLines / totalLines) * 100 : 100;
-
-    const functionsCoveragePercentage =
-      totalFunctions > 0 ? (coveredFunctions / totalFunctions) * 100 : 100;
-
-    const branchesCoveragePercentage =
-      totalBranches > 0 ? (coveredBranches / totalBranches) * 100 : 100;
-
-    const totalElements = totalLines + totalFunctions + totalBranches;
-    const coveredElements = coveredLines + coveredFunctions + coveredBranches;
-
-    const overallCoveragePercentage =
-      totalElements > 0 ? (coveredElements / totalElements) * 100 : 100;
 
     return {
       totalChangedFiles: changedFiles.length,
       filesWithCoverage,
       filesWithoutCoverage,
-      overallCoverage: {
-        totalLines,
-        coveredLines,
-        totalFunctions,
-        coveredFunctions,
-        totalBranches,
-        coveredBranches,
-        linesCoveragePercentage:
-          Math.round(linesCoveragePercentage * 100) / 100,
-        functionsCoveragePercentage:
-          Math.round(functionsCoveragePercentage * 100) / 100,
-        branchesCoveragePercentage:
-          Math.round(branchesCoveragePercentage * 100) / 100,
-        overallCoveragePercentage:
-          Math.round(overallCoveragePercentage * 100) / 100,
-      },
+      overallCoverage: this.analysisFromCounts(aggregate),
     };
   }
 
@@ -244,10 +233,7 @@ export class CoverageAnalyzer {
     functions: FunctionCoverage[];
   }> {
     return analysis.changedFiles
-      .filter(
-        (file): file is FileChangeWithCoverage & { coverage: FileCoverage } =>
-          !!file.coverage,
-      )
+      .filter(this.withCoverage)
       .map((file) => ({
         file: file.path,
         functions: file.coverage.functions.filter((fn) => fn.hit === 0),
@@ -263,10 +249,7 @@ export class CoverageAnalyzer {
     lines: number[];
   }> {
     return analysis.changedFiles
-      .filter(
-        (file): file is FileChangeWithCoverage & { coverage: FileCoverage } =>
-          !!file.coverage,
-      )
+      .filter(this.withCoverage)
       .map((file) => ({
         file: file.path,
         lines: file.coverage.lines

--- a/src/coverageGating.ts
+++ b/src/coverageGating.ts
@@ -27,42 +27,34 @@ export class CoverageGating {
           )
         : 100;
 
-    if (threshold === 0) {
-      // Project baseline mode
-      const meetsThreshold =
-        prCoveragePercentage >= overallProjectCoveragePercentage;
+    // When threshold is 0 we gate against the project's own coverage
+    // (baseline mode); otherwise against the explicit threshold.
+    const isBaseline = threshold === 0;
+    const requiredCoverage = isBaseline
+      ? overallProjectCoveragePercentage
+      : threshold;
+    const meetsThreshold = prCoveragePercentage >= requiredCoverage;
 
-      return {
-        meetsThreshold,
-        threshold,
-        mode: "baseline",
-        prCoveragePercentage,
-        overallProjectCoveragePercentage,
-        description: meetsThreshold
-          ? `✅ PR coverage (${prCoveragePercentage}%) meets or exceeds overall project coverage (${overallProjectCoveragePercentage}%)`
-          : `❌ PR coverage (${prCoveragePercentage}%) is below overall project coverage (${overallProjectCoveragePercentage}%)`,
-        errorMessage: meetsThreshold
-          ? undefined
-          : `Coverage gating failed: PR changes coverage (${prCoveragePercentage}%) is lower than overall project coverage (${overallProjectCoveragePercentage}%)`,
-      };
-    } else {
-      // Standard threshold mode
-      const meetsThreshold = prCoveragePercentage >= threshold;
+    const target = isBaseline
+      ? `overall project coverage (${overallProjectCoveragePercentage}%)`
+      : `threshold (${threshold}%)`;
+    const failureReason = isBaseline
+      ? `is lower than overall project coverage (${overallProjectCoveragePercentage}%)`
+      : `is below threshold (${threshold}%)`;
 
-      return {
-        meetsThreshold,
-        threshold,
-        mode: "standard",
-        prCoveragePercentage,
-        overallProjectCoveragePercentage,
-        description: meetsThreshold
-          ? `✅ PR coverage (${prCoveragePercentage}%) meets or exceeds threshold (${threshold}%)`
-          : `❌ PR coverage (${prCoveragePercentage}%) is below threshold (${threshold}%)`,
-        errorMessage: meetsThreshold
-          ? undefined
-          : `Coverage gating failed: PR changes coverage (${prCoveragePercentage}%) is below threshold (${threshold}%)`,
-      };
-    }
+    return {
+      meetsThreshold,
+      threshold,
+      mode: isBaseline ? "baseline" : "standard",
+      prCoveragePercentage,
+      overallProjectCoveragePercentage,
+      description: meetsThreshold
+        ? `✅ PR coverage (${prCoveragePercentage}%) meets or exceeds ${target}`
+        : `❌ PR coverage (${prCoveragePercentage}%) is below ${target}`,
+      errorMessage: meetsThreshold
+        ? undefined
+        : `Coverage gating failed: PR changes coverage (${prCoveragePercentage}%) ${failureReason}`,
+    };
   }
 
   static format(result: GatingResult): string {


### PR DESCRIPTION
## Summary

Deep clean-code refactor of the **coverage** module group (`coverageAnalyzer`, `coverageGating`). All returned object shapes and every user-visible string (including emojis and box-drawing characters) are byte-for-byte identical — only internal structure changed.

### `coverageAnalyzer.ts`
- Extracted `percentage(hit, found)` (100% when `found === 0`) and `round2(value)` helpers, replacing the `found > 0 ? (hit/found)*100 : 100` / `Math.round(x*100)/100` pattern that was repeated for lines/functions/branches/overall in both `calculateFileAnalysis` and `calculateSummary`.
- Introduced `analysisFromCounts(counts)` as the single place that builds the 10-field analysis object (incl. the weighted overall), reused by both file- and summary-level computation.
- Hoisted the zero-filled no-coverage-data object to a single `EMPTY_FILE_ANALYSIS` constant. The 0% (no data) vs 100% (coverable-but-empty metric) distinction is intentionally preserved.
- Extracted the shared `coverage`-narrowing type guard `withCoverage` used by `getUncoveredFunctions`/`getUncoveredLines`.

### `coverageGating.ts`
- Collapsed the duplicated baseline/standard branches of `evaluate` into a single result construction driven by `isBaseline`/`requiredCoverage`, keeping the differing wording ("meets or exceeds … project coverage" vs "… threshold", and "is lower than … coverage" vs "is below threshold") exactly.

The `lcov/` submodule was reviewed but left unchanged (already clean from a prior refactor).

## Testing

- All existing unit tests pass with no test weakening; `coverageAnalyzer.ts` and `coverageGating.ts` remain at 100% coverage.
- The exact-string assertions in the gating/analyzer tests confirm output is unchanged after the dedup.
- Confirmed the rebuilt `dist/` bundle still smoke-tests to input parsing.

Part of the multi-PR clean-code restructuring (follows #50, #51).