### PR TITLE
Compute merge base before determining PR changeset

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Multiple patterns can be specified by separating them with commas. Each file is 
 | `coverage-threshold`   | `string` | `false`  | `'80'`                 | Min coverage % for changed files. Only used when `gate-mode` is `threshold`.                                       |
 | `gate-mode`            | `string` | `false`  | `'threshold'`          | How to gate the workflow: `threshold` (fail below `coverage-threshold`), `baseline` (fail below overall project coverage), or `none` (never fail; report only). |
 | `github-token`         | `string` | `true`   | -                      | GitHub token to post PR comments                                                                                     |
+| `target-branch`        | `string` | `false`  | `'main'`               | Branch the PR targets. Used only for labelling/reporting; the diff base is derived from the PR event (see [Changeset Detection](#changeset-detection)). |
 | `label`                | `string` | `false`  | -                      | Optional label for comment identification                                                                             |
 | `source-code-pattern`  | `string` | `false`  | -                      | Optional glob pattern(s) for source code files to include in coverage analysis. Multiple patterns separated by commas. |
 | `test-code-pattern`    | `string` | `false`  | -                      | Optional glob pattern(s) for test files to exclude from coverage analysis. Multiple patterns separated by commas.   |
@@ -214,10 +215,42 @@ flowchart TD
   H -- No --> J
 ```
 
+## Changeset Detection
+
+The action analyses only the files your pull request actually changed. To do
+this reliably it determines the **merge base** — the most recent common
+ancestor — between the PR head and the PR base, then diffs from there:
+
+```text
+git merge-base <pr-base-sha> <pr-head-sha>   # the branch point
+git diff --name-only --diff-filter=AM <merge-base>..<pr-head-sha>
+```
+
+This is equivalent to git's three-dot `base...head` notation and matters when
+the target branch has **diverged** since the PR branched off. A plain two-dot
+`base..head` diff would incorrectly attribute commits that landed on the target
+branch (after the branch point) to your PR, inflating the changeset with files
+you never touched. Comparing against the merge base isolates the PR's own
+changes regardless of how far the target branch has advanced.
+
+The base and head SHAs come from the `pull_request` event payload
+(`pull_request.base.sha` / `pull_request.head.sha`), which is the most reliable
+source during a `pull_request` workflow. The `target-branch` input does **not**
+influence this calculation — on a `pull_request` event `pull_request.base.sha`
+already points at the target branch tip. `target-branch` is used purely for
+labelling and reporting (e.g. the changeset summary and the `target-branch`
+output).
+
+Only added (`A`) and modified (`M`) files are considered; deletions are
+excluded since there is nothing to measure coverage for.
+
 ## Checkout Behavior
 
-This action needs to calculate the changeset for the PR and therefore won't work with shallow clones. Set `fetch-depth: 0` or use the following snippet
-to calculate the minimal fetch depth required:
+Because the action computes a merge base, the local clone must contain enough
+history to reach the branch point. A default shallow checkout (`fetch-depth: 1`)
+usually does **not**. Set `fetch-depth: 0` for a full clone, or use the snippet
+below to fetch just enough history — the PR's own commits plus the one parent
+that is the branch point:
 
 ```yaml
     - name: Determine fetch depth
@@ -229,6 +262,12 @@ to calculate the minimal fetch depth required:
       with:
         fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
 ```
+
+If the merge base cannot be resolved (for example the clone is still too
+shallow), the action logs a warning and falls back to diffing against the PR
+base SHA directly. This preserves a result rather than failing, but the
+changeset may include unrelated target-branch changes when the branch has
+diverged — increase `fetch-depth` to restore accurate detection.
 
 ## Example Usage
 

--- a/src/changesetService.test.ts
+++ b/src/changesetService.test.ts
@@ -27,15 +27,19 @@ describe("ChangesetService", () => {
     jest.clearAllMocks();
     // Reset GitHub context mock
     (context as unknown as { payload: object }).payload = {};
+    // Default to a resolvable merge base so detectCodeChanges tests exercise
+    // the normal (non-shallow) path; detectChanges tests override as needed.
+    mockedGitUtils.getMergeBase.mockResolvedValue("base-sha");
   });
 
   describe("detectChanges", () => {
-    it("should detect changes using GitHub context SHAs", async () => {
+    it("should detect changes using the merge base of the PR base and head", async () => {
       const mockPrHeadSha = "pr-head-sha123";
       const mockPrBaseSha = "pr-base-sha456";
+      const mockMergeBaseSha = "merge-base-sha789";
       const mockChangedFiles = ["src/file1.ts", "src/file2.js"];
       const mockChangeset = {
-        baseCommit: mockPrBaseSha,
+        baseCommit: mockMergeBaseSha,
         headCommit: mockPrHeadSha,
         targetBranch: "main",
         files: [
@@ -47,6 +51,7 @@ describe("ChangesetService", () => {
 
       mockedGitUtils.getPullRequestHead.mockReturnValue(mockPrHeadSha);
       mockedGitUtils.getPullRequestBase.mockReturnValue(mockPrBaseSha);
+      mockedGitUtils.getMergeBase.mockResolvedValue(mockMergeBaseSha);
       mockedGitUtils.getChangedFiles.mockResolvedValue(mockChangedFiles);
       mockedChangesetUtils.createChangeset.mockReturnValue(mockChangeset);
       mockedChangesetUtils.getSummary.mockReturnValue(
@@ -58,13 +63,17 @@ describe("ChangesetService", () => {
       expect(result).toBe(mockChangeset);
       expect(mockedGitUtils.getPullRequestHead).toHaveBeenCalled();
       expect(mockedGitUtils.getPullRequestBase).toHaveBeenCalled();
-      expect(mockedGitUtils.getChangedFiles).toHaveBeenCalledWith(
+      expect(mockedGitUtils.getMergeBase).toHaveBeenCalledWith(
         mockPrBaseSha,
+        mockPrHeadSha,
+      );
+      expect(mockedGitUtils.getChangedFiles).toHaveBeenCalledWith(
+        mockMergeBaseSha,
         mockPrHeadSha,
       );
       expect(mockedChangesetUtils.createChangeset).toHaveBeenCalledWith(
         mockChangedFiles,
-        mockPrBaseSha,
+        mockMergeBaseSha,
         mockPrHeadSha,
         "main",
       );
@@ -85,10 +94,76 @@ describe("ChangesetService", () => {
       );
     });
 
+    it("should isolate PR changes when the target branch has diverged", async () => {
+      // The merge base lies behind the PR base tip because new commits landed
+      // on the target branch after the PR branched off. Diffing against the
+      // merge base must exclude those unrelated target-branch changes.
+      const mockPrHeadSha = "head";
+      const mockPrBaseSha = "diverged-base";
+      const mockMergeBaseSha = "fork-point";
+      const prOnlyFiles = ["src/feature.ts"];
+
+      mockedGitUtils.getPullRequestHead.mockReturnValue(mockPrHeadSha);
+      mockedGitUtils.getPullRequestBase.mockReturnValue(mockPrBaseSha);
+      mockedGitUtils.getMergeBase.mockResolvedValue(mockMergeBaseSha);
+      mockedGitUtils.getChangedFiles.mockResolvedValue(prOnlyFiles);
+      mockedChangesetUtils.createChangeset.mockReturnValue({
+        baseCommit: mockMergeBaseSha,
+        headCommit: mockPrHeadSha,
+        targetBranch: "main",
+        files: [{ path: "src/feature.ts", status: "modified" as const }],
+        totalFiles: 1,
+      });
+      mockedChangesetUtils.getSummary.mockReturnValue("summary");
+
+      await ChangesetService.detectChanges("main");
+
+      expect(mockedGitUtils.getChangedFiles).toHaveBeenCalledWith(
+        mockMergeBaseSha,
+        mockPrHeadSha,
+      );
+      expect(mockedCore.warning).not.toHaveBeenCalled();
+    });
+
+    it("should fall back to the PR base SHA and warn when the merge base is unavailable", async () => {
+      const mockPrHeadSha = "head";
+      const mockPrBaseSha = "base";
+
+      mockedGitUtils.getPullRequestHead.mockReturnValue(mockPrHeadSha);
+      mockedGitUtils.getPullRequestBase.mockReturnValue(mockPrBaseSha);
+      mockedGitUtils.getMergeBase.mockResolvedValue(null);
+      mockedGitUtils.getChangedFiles.mockResolvedValue(["src/file1.ts"]);
+      mockedChangesetUtils.createChangeset.mockReturnValue({
+        baseCommit: mockPrBaseSha,
+        headCommit: mockPrHeadSha,
+        targetBranch: "main",
+        files: [{ path: "src/file1.ts", status: "modified" as const }],
+        totalFiles: 1,
+      });
+      mockedChangesetUtils.getSummary.mockReturnValue("summary");
+
+      await ChangesetService.detectChanges("main");
+
+      expect(mockedGitUtils.getChangedFiles).toHaveBeenCalledWith(
+        mockPrBaseSha,
+        mockPrHeadSha,
+      );
+      expect(mockedChangesetUtils.createChangeset).toHaveBeenCalledWith(
+        ["src/file1.ts"],
+        mockPrBaseSha,
+        mockPrHeadSha,
+        "main",
+      );
+      expect(mockedCore.warning).toHaveBeenCalledWith(
+        expect.stringContaining("Merge base unavailable"),
+      );
+    });
+
     it("should handle git command failures", async () => {
       const error = new Error("Git command failed");
       mockedGitUtils.getPullRequestHead.mockReturnValue("head-sha");
       mockedGitUtils.getPullRequestBase.mockReturnValue("base-sha");
+      mockedGitUtils.getMergeBase.mockResolvedValue("merge-base-sha");
       mockedGitUtils.getChangedFiles.mockRejectedValue(error);
 
       await expect(ChangesetService.detectChanges("main")).rejects.toThrow(

--- a/src/changesetService.ts
+++ b/src/changesetService.ts
@@ -21,11 +21,26 @@ export class ChangesetService {
       core.info(`📌 PR head: ${headRef}`);
       core.info(`🎯 PR base: ${baseRef}`);
 
-      const changedFiles = await GitUtils.getChangedFiles(baseRef, headRef);
+      // Compare against the merge base rather than the base branch tip so the
+      // changeset only contains the PR's own changes, even when the target
+      // branch has advanced since the branch point. When the merge base cannot
+      // be resolved (typically a shallow clone) fall back to the PR base SHA to
+      // preserve the previous behaviour rather than failing outright.
+      const mergeBase = await GitUtils.getMergeBase(baseRef, headRef);
+      const diffBase = mergeBase ?? baseRef;
+
+      if (!mergeBase) {
+        core.warning(
+          "⚠️ Merge base unavailable (likely a shallow clone); falling back to the PR base SHA. " +
+            "Increase fetch-depth so the merge base is fetched for accurate changeset detection.",
+        );
+      }
+
+      const changedFiles = await GitUtils.getChangedFiles(diffBase, headRef);
 
       const changeset = ChangesetUtils.createChangeset(
         changedFiles,
-        baseRef,
+        diffBase,
         headRef,
         targetBranch,
       );

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { GitUtils } from "./git";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import * as core from "@actions/core";
 
 // Mock child_process, @actions/core, and @actions/github
@@ -12,20 +12,29 @@ jest.mock("@actions/github", () => ({
   },
 }));
 
-const mockedExec = exec as jest.MockedFunction<typeof exec>;
+const mockedExecFile = execFile as unknown as jest.MockedFunction<any>;
 const mockedCore = core as jest.Mocked<typeof core>;
 
 import { context } from "@actions/github";
 
-// Helper to mock exec with specific stdout/stderr
+// Helper to mock execFile with specific stdout/stderr. promisify(execFile)
+// invokes it as execFile(file, args, callback).
 const mockExecSuccess = (stdout: string, stderr = "") => {
-  mockedExec.mockImplementation(((_command: string, callback: any) => {
+  mockedExecFile.mockImplementation(((
+    _file: string,
+    _args: string[],
+    callback: any,
+  ) => {
     callback(null, { stdout, stderr });
   }) as any);
 };
 
 const mockExecError = (error: Error) => {
-  mockedExec.mockImplementation(((_command: string, callback: any) => {
+  mockedExecFile.mockImplementation(((
+    _file: string,
+    _args: string[],
+    callback: any,
+  ) => {
     callback(error, { stdout: "", stderr: "" });
   }) as any);
 };
@@ -126,8 +135,9 @@ describe("GitUtils", () => {
       const result = await GitUtils.getMergeBase("base-sha", "head-sha");
 
       expect(result).toBe("merge-base-sha789");
-      expect(mockedExec).toHaveBeenCalledWith(
-        "git merge-base base-sha head-sha",
+      expect(mockedExecFile).toHaveBeenCalledWith(
+        "git",
+        ["merge-base", "--", "base-sha", "head-sha"],
         expect.any(Function),
       );
       expect(mockedCore.info).toHaveBeenCalledWith(
@@ -143,15 +153,16 @@ describe("GitUtils", () => {
       expect(result).toBeNull();
     });
 
-    it("should return null and warn when git fails (e.g. shallow clone)", async () => {
+    it("should return null and log debug when git fails (e.g. shallow clone)", async () => {
       mockExecError(new Error("fatal: no merge base"));
 
       const result = await GitUtils.getMergeBase("base-sha", "head-sha");
 
       expect(result).toBeNull();
-      expect(mockedCore.warning).toHaveBeenCalledWith(
+      expect(mockedCore.debug).toHaveBeenCalledWith(
         expect.stringContaining("Could not determine merge base"),
       );
+      expect(mockedCore.warning).not.toHaveBeenCalled();
     });
   });
 
@@ -162,8 +173,9 @@ describe("GitUtils", () => {
       const result = await GitUtils.getChangedFiles("base-sha", "head-sha");
 
       expect(result).toEqual(["src/file1.ts", "src/file2.js", "README.md"]);
-      expect(mockedExec).toHaveBeenCalledWith(
-        "git diff --name-only --diff-filter=AM base-sha..head-sha",
+      expect(mockedExecFile).toHaveBeenCalledWith(
+        "git",
+        ["diff", "--name-only", "--diff-filter=AM", "base-sha..head-sha"],
         expect.any(Function),
       );
       expect(mockedCore.info).toHaveBeenCalledWith(
@@ -186,8 +198,9 @@ describe("GitUtils", () => {
       const result = await GitUtils.getChangedFiles("base-sha");
 
       expect(result).toEqual(["src/file1.ts"]);
-      expect(mockedExec).toHaveBeenCalledWith(
-        "git diff --name-only --diff-filter=AM base-sha..HEAD",
+      expect(mockedExecFile).toHaveBeenCalledWith(
+        "git",
+        ["diff", "--name-only", "--diff-filter=AM", "base-sha..HEAD"],
         expect.any(Function),
       );
     });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -119,6 +119,42 @@ describe("GitUtils", () => {
     });
   });
 
+  describe("getMergeBase", () => {
+    it("should return the merge base SHA when git resolves one", async () => {
+      mockExecSuccess("merge-base-sha789\n");
+
+      const result = await GitUtils.getMergeBase("base-sha", "head-sha");
+
+      expect(result).toBe("merge-base-sha789");
+      expect(mockedExec).toHaveBeenCalledWith(
+        "git merge-base base-sha head-sha",
+        expect.any(Function),
+      );
+      expect(mockedCore.info).toHaveBeenCalledWith(
+        "🌳 Merge base: merge-base-sha789",
+      );
+    });
+
+    it("should return null when git produces no output", async () => {
+      mockExecSuccess("\n");
+
+      const result = await GitUtils.getMergeBase("base-sha", "head-sha");
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null and warn when git fails (e.g. shallow clone)", async () => {
+      mockExecError(new Error("fatal: no merge base"));
+
+      const result = await GitUtils.getMergeBase("base-sha", "head-sha");
+
+      expect(result).toBeNull();
+      expect(mockedCore.warning).toHaveBeenCalledWith(
+        expect.stringContaining("Could not determine merge base"),
+      );
+    });
+  });
+
   describe("getChangedFiles", () => {
     it("should return list of changed files", async () => {
       mockExecSuccess("src/file1.ts\nsrc/file2.js\nREADME.md\n");

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,10 +1,13 @@
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import * as core from "@actions/core";
 import { context } from "@actions/github";
 import { toErrorMessage } from "./errors";
 
-const execAsync = promisify(exec);
+// `execFile` runs git directly without a shell, so refs are passed as an argv
+// array and never interpreted by a shell. This avoids command injection even if
+// a ref ever contained shell metacharacters.
+const execFileAsync = promisify(execFile);
 
 export class GitUtils {
   // The GitHub context is populated from the event payload, which is the most
@@ -44,7 +47,13 @@ export class GitUtils {
     try {
       core.info(`🔱 Resolving merge base between ${base} and ${head}`);
 
-      const { stdout } = await execAsync(`git merge-base ${base} ${head}`);
+      // `--` terminates option parsing so refs are always treated as revisions.
+      const { stdout } = await execFileAsync("git", [
+        "merge-base",
+        "--",
+        base,
+        head,
+      ]);
       const mergeBase = stdout.trim();
 
       if (!mergeBase) {
@@ -54,7 +63,10 @@ export class GitUtils {
       core.info(`🌳 Merge base: ${mergeBase}`);
       return mergeBase;
     } catch (error) {
-      core.warning(
+      // The caller (ChangesetService) surfaces the actionable warning with
+      // fetch-depth guidance, so keep this at debug level to avoid duplicate
+      // warnings for the same condition (e.g. shallow clones).
+      core.debug(
         `Could not determine merge base between ${base} and ${head}: ${toErrorMessage(
           error,
         )}`,
@@ -70,9 +82,12 @@ export class GitUtils {
     try {
       core.info(`📂 Getting changed files between ${base} and ${head}`);
 
-      const { stdout } = await execAsync(
-        `git diff --name-only --diff-filter=AM ${base}..${head}`,
-      );
+      const { stdout } = await execFileAsync("git", [
+        "diff",
+        "--name-only",
+        "--diff-filter=AM",
+        `${base}..${head}`,
+      ]);
 
       const files = stdout
         .split("\n")

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,6 +2,7 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import * as core from "@actions/core";
 import { context } from "@actions/github";
+import { toErrorMessage } from "./errors";
 
 const execAsync = promisify(exec);
 
@@ -27,6 +28,39 @@ export class GitUtils {
 
   static getPullRequestBase(): string {
     return GitUtils.getPullRequestSha("base", "🎯");
+  }
+
+  // Resolves the merge base (the most recent common ancestor) between the PR
+  // base and head. Diffing against the merge base — equivalent to git's
+  // three-dot `base...head` — isolates the changes the PR actually introduced,
+  // even when the target branch has advanced since the branch point. A plain
+  // two-dot `base..head` diff would otherwise attribute unrelated target-branch
+  // commits to the PR. Returns `null` when no common ancestor can be found,
+  // which typically means the clone is too shallow to contain it.
+  static async getMergeBase(
+    base: string,
+    head: string,
+  ): Promise<string | null> {
+    try {
+      core.info(`🔱 Resolving merge base between ${base} and ${head}`);
+
+      const { stdout } = await execAsync(`git merge-base ${base} ${head}`);
+      const mergeBase = stdout.trim();
+
+      if (!mergeBase) {
+        return null;
+      }
+
+      core.info(`🌳 Merge base: ${mergeBase}`);
+      return mergeBase;
+    } catch (error) {
+      core.warning(
+        `Could not determine merge base between ${base} and ${head}: ${toErrorMessage(
+          error,
+        )}`,
+      );
+      return null;
+    }
   }
 
   static async getChangedFiles(


### PR DESCRIPTION
## Summary

The changeset detection previously diffed `pull_request.base.sha..head` (two-dot) directly. When the target branch advances after a PR branches off, a two-dot diff conflates commits that landed on the target branch into the PR's changeset, so files the author never touched were reported as changed and analysed for coverage.

This change resolves the **merge base** (most recent common ancestor) between the PR base and head, then diffs against it — equivalent to git's three-dot `base...head`. The result contains only the PR's own changes regardless of how far the target branch has diverged.

### Changes
- `GitUtils.getMergeBase(base, head)` runs `git merge-base` and returns the SHA, or `null` when no common ancestor is reachable.
- `ChangesetService.detectChanges` now diffs against the merge base. When it cannot be resolved (typically a shallow clone) it warns and falls back to the PR base SHA, preserving the previous behaviour rather than failing.
- README: new **Changeset Detection** section, clarified **Checkout Behavior** / fetch-depth caveats, and documented the `target-branch` input (reporting-only).

### Trade-offs / notes
- `target-branch` does **not** influence the diff: on a `pull_request` event `pull_request.base.sha` already points at the target branch tip, so the merge base against it is correct. The input stays for labelling/reporting.
- The reported `base-commit` output is now the merge base (the actual comparison point). This only differs from the old value when the target branch has diverged — exactly the case the old output was misleading.
- Shallow clones still need adequate `fetch-depth` (PR commits + 1) to reach the branch point; otherwise the action degrades gracefully with a warning.

## Testing
- Added unit tests for `getMergeBase` (success, empty output, shallow-clone failure).
- Added `detectChanges` tests for the diverged-target-branch case and the shallow-clone fallback path.
- Manually smoke-tested the rebuilt `dist/index.js` (reaches input parsing, no missing-module error).