### PR TITLE
Add gate-mode input to select coverage gating behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
       id: coveragemap
       with:
         lcov-file: "./coverage/lcov.info"
+        gate-mode: threshold
         coverage-threshold: "80"
         github-token: ${{ secrets.GITHUB_TOKEN }}
         github-app-id: ${{ secrets.COVERAGEMAP_APP_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
       id: coveragemap
       with:
         lcov-file: "./coverage/lcov.info"
-        gate-mode: threshold
         coverage-threshold: "80"
         github-token: ${{ secrets.GITHUB_TOKEN }}
         github-app-id: ${{ secrets.COVERAGEMAP_APP_ID }}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Multiple patterns can be specified by separating them with commas. Each file is 
 | :--------------------- | :------- | :------- | :--------------------- | :-------------------------------------------------------------------------------------------------------------------- |
 | `lcov-file`            | `string` | `true`   | `'coverage/lcov.info'` | Path to the lcov.info report                                                                                         |
 | `coverage-threshold`   | `string` | `false`  | `'80'`                 | Min coverage % for changed files. Only used when `gate-mode` is `threshold`.                                       |
-| `gate-mode`            | `string` | `false`  | `'baseline'`           | How to gate the workflow: `threshold` (fail below `coverage-threshold`), `baseline` (fail below overall project coverage), or `none` (never fail; report only). |
+| `gate-mode`            | `string` | `false`  | `'threshold'`          | How to gate the workflow: `threshold` (fail below `coverage-threshold`), `baseline` (fail below overall project coverage), or `none` (never fail; report only). |
 | `github-token`         | `string` | `true`   | -                      | GitHub token to post PR comments                                                                                     |
 | `label`                | `string` | `false`  | -                      | Optional label for comment identification                                                                             |
 | `source-code-pattern`  | `string` | `false`  | -                      | Optional glob pattern(s) for source code files to include in coverage analysis. Multiple patterns separated by commas. |
@@ -137,7 +137,7 @@ Multiple patterns can be specified by separating them with commas. Each file is 
 
 The action includes sophisticated threshold gating to enforce coverage standards. The gating behavior is selected with the `gate-mode` input.
 
-### Standard Threshold Mode (`gate-mode: threshold`)
+### Standard Threshold Mode (`gate-mode: threshold`, default)
 
 The action enforces that the coverage percentage of changed files meets `coverage-threshold`:
 
@@ -146,7 +146,7 @@ The action enforces that the coverage percentage of changed files meets `coverag
 
 Example: With `coverage-threshold: 80`, the action passes only if changed files have ≥80% coverage.
 
-### Project Baseline Mode (`gate-mode: baseline`, default)
+### Project Baseline Mode (`gate-mode: baseline`)
 
 The action compares PR coverage against the overall project coverage:
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Multiple patterns can be specified by separating them with commas. Each file is 
 | Name                   | Type     | Required | Default                | Description                                                                                                           |
 | :--------------------- | :------- | :------- | :--------------------- | :-------------------------------------------------------------------------------------------------------------------- |
 | `lcov-file`            | `string` | `true`   | `'coverage/lcov.info'` | Path to the lcov.info report                                                                                         |
-| `coverage-threshold`   | `string` | `true`   | `'80'`                 | Min coverage % for changed files. Only used when `gate-mode` is `threshold`.                                       |
-| `gate-mode`            | `string` | `false`  | `'threshold'`          | How to gate the workflow: `threshold` (fail below `coverage-threshold`), `baseline` (fail below overall project coverage), or `none` (never fail; report only). |
+| `coverage-threshold`   | `string` | `false`  | `'80'`                 | Min coverage % for changed files. Only used when `gate-mode` is `threshold`.                                       |
+| `gate-mode`            | `string` | `false`  | `'baseline'`           | How to gate the workflow: `threshold` (fail below `coverage-threshold`), `baseline` (fail below overall project coverage), or `none` (never fail; report only). |
 | `github-token`         | `string` | `true`   | -                      | GitHub token to post PR comments                                                                                     |
 | `label`                | `string` | `false`  | -                      | Optional label for comment identification                                                                             |
 | `source-code-pattern`  | `string` | `false`  | -                      | Optional glob pattern(s) for source code files to include in coverage analysis. Multiple patterns separated by commas. |
@@ -137,7 +137,7 @@ Multiple patterns can be specified by separating them with commas. Each file is 
 
 The action includes sophisticated threshold gating to enforce coverage standards. The gating behavior is selected with the `gate-mode` input.
 
-### Standard Threshold Mode (`gate-mode: threshold`, default)
+### Standard Threshold Mode (`gate-mode: threshold`)
 
 The action enforces that the coverage percentage of changed files meets `coverage-threshold`:
 
@@ -146,7 +146,7 @@ The action enforces that the coverage percentage of changed files meets `coverag
 
 Example: With `coverage-threshold: 80`, the action passes only if changed files have ≥80% coverage.
 
-### Project Baseline Mode (`gate-mode: baseline`)
+### Project Baseline Mode (`gate-mode: baseline`, default)
 
 The action compares PR coverage against the overall project coverage:
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Multiple patterns can be specified by separating them with commas. Each file is 
 | Name                   | Type     | Required | Default                | Description                                                                                                           |
 | :--------------------- | :------- | :------- | :--------------------- | :-------------------------------------------------------------------------------------------------------------------- |
 | `lcov-file`            | `string` | `true`   | `'coverage/lcov.info'` | Path to the lcov.info report                                                                                         |
-| `coverage-threshold`   | `string` | `true`   | `'80'`                 | Min coverage % for changed files. Set to '0' to compare PR coverage against overall project coverage instead.      |
+| `coverage-threshold`   | `string` | `true`   | `'80'`                 | Min coverage % for changed files. Only used when `gate-mode` is `threshold`.                                       |
+| `gate-mode`            | `string` | `false`  | `'threshold'`          | How to gate the workflow: `threshold` (fail below `coverage-threshold`), `baseline` (fail below overall project coverage), or `none` (never fail; report only). |
 | `github-token`         | `string` | `true`   | -                      | GitHub token to post PR comments                                                                                     |
 | `label`                | `string` | `false`  | -                      | Optional label for comment identification                                                                             |
 | `source-code-pattern`  | `string` | `false`  | -                      | Optional glob pattern(s) for source code files to include in coverage analysis. Multiple patterns separated by commas. |
@@ -134,25 +135,31 @@ Multiple patterns can be specified by separating them with commas. Each file is 
 
 ## Coverage Threshold Gating
 
-The action includes sophisticated threshold gating to enforce coverage standards:
+The action includes sophisticated threshold gating to enforce coverage standards. The gating behavior is selected with the `gate-mode` input.
 
-### Standard Threshold Mode (threshold > 0)
+### Standard Threshold Mode (`gate-mode: threshold`, default)
 
-When `coverage-threshold` is set to a value greater than 0, the action enforces that the coverage percentage of changed files meets this threshold:
+The action enforces that the coverage percentage of changed files meets `coverage-threshold`:
 
   - ✅ **Pass**: If PR changes have coverage ≥ threshold
   - ❌ **Fail**: If PR changes have coverage < threshold
 
 Example: With `coverage-threshold: 80`, the action passes only if changed files have ≥80% coverage.
 
-### Project Baseline Mode (threshold = 0)
+### Project Baseline Mode (`gate-mode: baseline`)
 
-When `coverage-threshold` is set to `"0"`, the action compares PR coverage against the overall project coverage:
+The action compares PR coverage against the overall project coverage:
 
   - ✅ **Pass**: If PR changes have coverage ≥ overall project coverage
   - ❌ **Fail**: If PR changes have coverage < overall project coverage
 
 This mode ensures new code doesn't lower the overall quality bar while allowing flexibility for projects with varying coverage levels.
+
+### Disabled Mode (`gate-mode: none`)
+
+The action measures and reports coverage but never fails the workflow. Use this to surface the treemap and PR comment without enforcing a gate, instead of having the caller workflow flag the step to ignore failures.
+
+  - ℹ️ **Always passes**: `meets-threshold` is reported as `true` and the PR comment shows a "Gating disabled" note.
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -14,16 +14,16 @@ inputs:
     description: |
       The minimum acceptable coverage percentage for changed files.
       Only used when gate-mode is "threshold".
-    required: true
+    required: false
     default: "80"
   gate-mode:
     description: |
       How to gate the workflow on coverage. One of:
-      - "threshold": fail when changed-files coverage is below coverage-threshold (default).
-      - "baseline": fail when changed-files coverage is below the overall project coverage.
+      - "threshold": fail when changed-files coverage is below coverage-threshold.
+      - "baseline": fail when changed-files coverage is below the overall project coverage (default).
       - "none": never fail the workflow; report coverage without gating.
     required: false
-    default: threshold
+    default: baseline
   target-branch:
     description: The target branch to compare changes against
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,17 @@ inputs:
   coverage-threshold:
     description: |
       The minimum acceptable coverage percentage for changed files.
-      Set to 0 to compare PR coverage against overall project coverage instead.
+      Only used when gate-mode is "threshold".
     required: true
     default: "80"
+  gate-mode:
+    description: |
+      How to gate the workflow on coverage. One of:
+      - "threshold": fail when changed-files coverage is below coverage-threshold (default).
+      - "baseline": fail when changed-files coverage is below the overall project coverage.
+      - "none": never fail the workflow; report coverage without gating.
+    required: false
+    default: threshold
   target-branch:
     description: The target branch to compare changes against
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -19,11 +19,11 @@ inputs:
   gate-mode:
     description: |
       How to gate the workflow on coverage. One of:
-      - "threshold": fail when changed-files coverage is below coverage-threshold.
-      - "baseline": fail when changed-files coverage is below the overall project coverage (default).
+      - "threshold": fail when changed-files coverage is below coverage-threshold (default).
+      - "baseline": fail when changed-files coverage is below the overall project coverage.
       - "none": never fail the workflow; report coverage without gating.
     required: false
-    default: baseline
+    default: threshold
   target-branch:
     description: The target branch to compare changes against
     required: false

--- a/src/coverageGating.test.ts
+++ b/src/coverageGating.test.ts
@@ -48,7 +48,12 @@ describe("CoverageGating", () => {
     describe("standard threshold mode", () => {
       it("should return success when PR coverage meets threshold", () => {
         const analysis = createMockAnalysis(85);
-        const result = CoverageGating.evaluate(analysis, mockLcovReport, 80);
+        const result = CoverageGating.evaluate(
+          analysis,
+          mockLcovReport,
+          "threshold",
+          80,
+        );
 
         expect(result).toEqual({
           meetsThreshold: true,
@@ -63,7 +68,12 @@ describe("CoverageGating", () => {
 
       it("should return failure when PR coverage is below threshold", () => {
         const analysis = createMockAnalysis(75);
-        const result = CoverageGating.evaluate(analysis, mockLcovReport, 80);
+        const result = CoverageGating.evaluate(
+          analysis,
+          mockLcovReport,
+          "threshold",
+          80,
+        );
 
         expect(result).toEqual({
           meetsThreshold: false,
@@ -79,7 +89,12 @@ describe("CoverageGating", () => {
 
       it("should return success when PR coverage exactly meets threshold", () => {
         const analysis = createMockAnalysis(80);
-        const result = CoverageGating.evaluate(analysis, mockLcovReport, 80);
+        const result = CoverageGating.evaluate(
+          analysis,
+          mockLcovReport,
+          "threshold",
+          80,
+        );
 
         expect(result.meetsThreshold).toBe(true);
         expect(result.prCoveragePercentage).toBe(80);
@@ -87,10 +102,15 @@ describe("CoverageGating", () => {
       });
     });
 
-    describe("baseline mode (threshold = 0)", () => {
+    describe("baseline mode", () => {
       it("should return success when PR coverage meets overall project coverage", () => {
         const analysis = createMockAnalysis(85);
-        const result = CoverageGating.evaluate(analysis, mockLcovReport, 0);
+        const result = CoverageGating.evaluate(
+          analysis,
+          mockLcovReport,
+          "baseline",
+          0,
+        );
 
         expect(result).toEqual({
           meetsThreshold: true,
@@ -106,7 +126,12 @@ describe("CoverageGating", () => {
 
       it("should return failure when PR coverage is below overall project coverage", () => {
         const analysis = createMockAnalysis(75);
-        const result = CoverageGating.evaluate(analysis, mockLcovReport, 0);
+        const result = CoverageGating.evaluate(
+          analysis,
+          mockLcovReport,
+          "baseline",
+          0,
+        );
 
         expect(result).toEqual({
           meetsThreshold: false,
@@ -123,11 +148,39 @@ describe("CoverageGating", () => {
 
       it("should return success when PR coverage exactly matches overall project coverage", () => {
         const analysis = createMockAnalysis(80);
-        const result = CoverageGating.evaluate(analysis, mockLcovReport, 0);
+        const result = CoverageGating.evaluate(
+          analysis,
+          mockLcovReport,
+          "baseline",
+          0,
+        );
 
         expect(result.meetsThreshold).toBe(true);
         expect(result.prCoveragePercentage).toBe(80);
         expect(result.overallProjectCoveragePercentage).toBe(80);
+      });
+    });
+
+    describe("none mode (gating disabled)", () => {
+      it("should always pass and report disabled mode even below threshold", () => {
+        const analysis = createMockAnalysis(10);
+        const result = CoverageGating.evaluate(
+          analysis,
+          mockLcovReport,
+          "none",
+          80,
+        );
+
+        expect(result).toEqual({
+          meetsThreshold: true,
+          threshold: 80,
+          mode: "disabled",
+          prCoveragePercentage: 10,
+          overallProjectCoveragePercentage: 80,
+          description:
+            "ℹ️ Coverage gating disabled — PR coverage (10%) is not enforced",
+          errorMessage: undefined,
+        });
       });
     });
 
@@ -147,7 +200,12 @@ describe("CoverageGating", () => {
         };
 
         const analysis = createMockAnalysis(50);
-        const result = CoverageGating.evaluate(analysis, emptyLcovReport, 0);
+        const result = CoverageGating.evaluate(
+          analysis,
+          emptyLcovReport,
+          "baseline",
+          0,
+        );
 
         expect(result.meetsThreshold).toBe(false);
         expect(result.overallProjectCoveragePercentage).toBe(100);
@@ -202,6 +260,27 @@ describe("CoverageGating", () => {
       );
       expect(formatted).toContain(
         "❌ PR coverage (75%) is below overall project coverage (80%)",
+      );
+    });
+
+    it("should format disabled mode result", () => {
+      const result: GatingResult = {
+        meetsThreshold: true,
+        threshold: 80,
+        mode: "disabled",
+        prCoveragePercentage: 42,
+        overallProjectCoveragePercentage: 80,
+        description:
+          "ℹ️ Coverage gating disabled — PR coverage (42%) is not enforced",
+      };
+
+      const formatted = CoverageGating.format(result);
+
+      expect(formatted).toContain("📊 Mode: Disabled");
+      expect(formatted).toContain("📈 PR Coverage: 42%");
+      expect(formatted).toContain("🎯 Requirement: none (gating disabled)");
+      expect(formatted).toContain(
+        "ℹ️ Coverage gating disabled — PR coverage (42%) is not enforced",
       );
     });
   });

--- a/src/coverageGating.ts
+++ b/src/coverageGating.ts
@@ -1,10 +1,11 @@
 import { CoverageAnalysis } from "./coverageAnalyzer";
 import { LcovReport } from "./lcov";
+import { GateMode } from "./inputs";
 
 export interface GatingResult {
   meetsThreshold: boolean;
   threshold: number;
-  mode: "standard" | "baseline";
+  mode: "standard" | "baseline" | "disabled";
   prCoveragePercentage: number;
   overallProjectCoveragePercentage?: number;
   description: string;
@@ -15,6 +16,7 @@ export class CoverageGating {
   static evaluate(
     analysis: CoverageAnalysis,
     lcovReport: LcovReport,
+    gateMode: GateMode,
     threshold: number,
   ): GatingResult {
     const prCoveragePercentage =
@@ -27,9 +29,23 @@ export class CoverageGating {
           )
         : 100;
 
-    // When threshold is 0 we gate against the project's own coverage
-    // (baseline mode); otherwise against the explicit threshold.
-    const isBaseline = threshold === 0;
+    // When gating is disabled the PR always passes; we still surface the
+    // measured coverage so the comment and logs stay informative.
+    if (gateMode === "none") {
+      return {
+        meetsThreshold: true,
+        threshold,
+        mode: "disabled",
+        prCoveragePercentage,
+        overallProjectCoveragePercentage,
+        description: `ℹ️ Coverage gating disabled — PR coverage (${prCoveragePercentage}%) is not enforced`,
+        errorMessage: undefined,
+      };
+    }
+
+    // Baseline mode gates against the project's own coverage; threshold mode
+    // gates against the explicit threshold value.
+    const isBaseline = gateMode === "baseline";
     const requiredCoverage = isBaseline
       ? overallProjectCoveragePercentage
       : threshold;
@@ -58,23 +74,30 @@ export class CoverageGating {
   }
 
   static format(result: GatingResult): string {
+    const modeLabel =
+      result.mode === "standard"
+        ? "Standard Threshold"
+        : result.mode === "baseline"
+          ? "Project Baseline"
+          : "Disabled";
+
     const lines = [
       "🎯 Coverage Gating Results",
       "═══════════════════════════",
       "",
-      `📊 Mode: ${
-        result.mode === "standard" ? "Standard Threshold" : "Project Baseline"
-      }`,
+      `📊 Mode: ${modeLabel}`,
       `📈 PR Coverage: ${result.prCoveragePercentage}%`,
     ];
 
     if (result.mode === "standard") {
       lines.push(`🎯 Threshold: ${result.threshold}%`);
-    } else {
+    } else if (result.mode === "baseline") {
       lines.push(
         `📊 Project Coverage: ${result.overallProjectCoveragePercentage}%`,
       );
       lines.push(`🎯 Requirement: PR coverage ≥ Project coverage`);
+    } else {
+      lines.push(`🎯 Requirement: none (gating disabled)`);
     }
 
     lines.push("");

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export async function run(): Promise<void> {
     const { analysis, gatingResult } = await analyzeCoverageAndGating(
       changeset,
       lcovReport,
+      inputs.gateMode,
       threshold,
     );
 

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -27,7 +27,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "./foo/bar.info",
       coverageThreshold: "85",
-      gateMode: "baseline",
+      gateMode: "threshold",
       targetBranch: "baz",
       githubToken: "test-token",
       label: "test-label",
@@ -56,7 +56,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
-      gateMode: "baseline",
+      gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -80,7 +80,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "./test/lcov.info",
       coverageThreshold: "80",
-      gateMode: "baseline",
+      gateMode: "threshold",
       targetBranch: "develop",
       githubToken: "test-token",
       label: undefined,
@@ -104,7 +104,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
-      gateMode: "baseline",
+      gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -128,7 +128,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "90",
-      gateMode: "baseline",
+      gateMode: "threshold",
       targetBranch: "develop",
       githubToken: "test-token",
       label: undefined,
@@ -150,7 +150,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
-      gateMode: "baseline",
+      gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -172,7 +172,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
-      gateMode: "baseline",
+      gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -184,11 +184,11 @@ describe("getInputs", () => {
   it("should parse an explicit gate-mode", () => {
     mockedCore.getInput.mockImplementation((name: string) => {
       if (name === "github-token") return "test-token";
-      if (name === "gate-mode") return "threshold";
+      if (name === "gate-mode") return "baseline";
       return "";
     });
 
-    expect(getInputs().gateMode).toBe("threshold");
+    expect(getInputs().gateMode).toBe("baseline");
   });
 
   it("should normalize gate-mode casing and surrounding whitespace", () => {

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -27,7 +27,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "./foo/bar.info",
       coverageThreshold: "85",
-      gateMode: "threshold",
+      gateMode: "baseline",
       targetBranch: "baz",
       githubToken: "test-token",
       label: "test-label",
@@ -56,7 +56,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
-      gateMode: "threshold",
+      gateMode: "baseline",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -80,7 +80,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "./test/lcov.info",
       coverageThreshold: "80",
-      gateMode: "threshold",
+      gateMode: "baseline",
       targetBranch: "develop",
       githubToken: "test-token",
       label: undefined,
@@ -104,7 +104,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
-      gateMode: "threshold",
+      gateMode: "baseline",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -128,7 +128,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "90",
-      gateMode: "threshold",
+      gateMode: "baseline",
       targetBranch: "develop",
       githubToken: "test-token",
       label: undefined,
@@ -150,7 +150,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
-      gateMode: "threshold",
+      gateMode: "baseline",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -172,7 +172,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
-      gateMode: "threshold",
+      gateMode: "baseline",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -184,17 +184,17 @@ describe("getInputs", () => {
   it("should parse an explicit gate-mode", () => {
     mockedCore.getInput.mockImplementation((name: string) => {
       if (name === "github-token") return "test-token";
-      if (name === "gate-mode") return "baseline";
+      if (name === "gate-mode") return "threshold";
       return "";
     });
 
-    expect(getInputs().gateMode).toBe("baseline");
+    expect(getInputs().gateMode).toBe("threshold");
   });
 
-  it("should normalize gate-mode casing", () => {
+  it("should normalize gate-mode casing and surrounding whitespace", () => {
     mockedCore.getInput.mockImplementation((name: string) => {
       if (name === "github-token") return "test-token";
-      if (name === "gate-mode") return "NONE";
+      if (name === "gate-mode") return "  NONE  ";
       return "";
     });
 

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -27,6 +27,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "./foo/bar.info",
       coverageThreshold: "85",
+      gateMode: "threshold",
       targetBranch: "baz",
       githubToken: "test-token",
       label: "test-label",
@@ -55,6 +56,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
+      gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -78,6 +80,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "./test/lcov.info",
       coverageThreshold: "80",
+      gateMode: "threshold",
       targetBranch: "develop",
       githubToken: "test-token",
       label: undefined,
@@ -101,6 +104,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
+      gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -124,6 +128,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "90",
+      gateMode: "threshold",
       targetBranch: "develop",
       githubToken: "test-token",
       label: undefined,
@@ -145,6 +150,7 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
+      gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
@@ -166,12 +172,45 @@ describe("getInputs", () => {
     expect(result).toEqual({
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
+      gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
       label: undefined,
       sourceCodePattern: "app/**/*.py",
       testCodePattern: undefined,
     });
+  });
+
+  it("should parse an explicit gate-mode", () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === "github-token") return "test-token";
+      if (name === "gate-mode") return "baseline";
+      return "";
+    });
+
+    expect(getInputs().gateMode).toBe("baseline");
+  });
+
+  it("should normalize gate-mode casing", () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === "github-token") return "test-token";
+      if (name === "gate-mode") return "NONE";
+      return "";
+    });
+
+    expect(getInputs().gateMode).toBe("none");
+  });
+
+  it("should throw on an invalid gate-mode", () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === "github-token") return "test-token";
+      if (name === "gate-mode") return "bogus";
+      return "";
+    });
+
+    expect(() => getInputs()).toThrow(
+      'Invalid gate-mode "bogus". Expected one of: threshold, baseline, none.',
+    );
   });
 });
 
@@ -184,6 +223,7 @@ describe("printInputs", () => {
     const inputs = {
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
+      gateMode: "threshold" as const,
       targetBranch: "main",
       githubToken: "test-token",
       label: "coverage",
@@ -197,6 +237,7 @@ describe("printInputs", () => {
       "📁 LCOV file: coverage/lcov.info",
     );
     expect(mockedCore.info).toHaveBeenCalledWith("📊 Coverage threshold: 80%");
+    expect(mockedCore.info).toHaveBeenCalledWith("🚦 Gate mode: threshold");
     expect(mockedCore.info).toHaveBeenCalledWith("🌿 Target branch: main");
     expect(mockedCore.info).toHaveBeenCalledWith("🔑 GitHub token: [PROVIDED]");
     expect(mockedCore.info).toHaveBeenCalledWith("🏷️ Label: coverage");
@@ -212,6 +253,7 @@ describe("printInputs", () => {
     const inputs = {
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
+      gateMode: "threshold" as const,
       targetBranch: "main",
       githubToken: "test-token",
     };
@@ -239,6 +281,7 @@ describe("printInputs", () => {
     const inputs = {
       lcovFile: "coverage/lcov.info",
       coverageThreshold: "80",
+      gateMode: "threshold" as const,
       targetBranch: "main",
       githubToken: "",
     };

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,8 +1,12 @@
 import * as core from "@actions/core";
 
+export const GATE_MODES = ["threshold", "baseline", "none"] as const;
+export type GateMode = (typeof GATE_MODES)[number];
+
 export interface ActionInputs {
   lcovFile: string;
   coverageThreshold: string;
+  gateMode: GateMode;
   targetBranch: string;
   githubToken: string;
   label?: string;
@@ -17,9 +21,20 @@ function optionalInput(name: string): string | undefined {
   return core.getInput(name) || undefined;
 }
 
+function parseGateMode(): GateMode {
+  const raw = (core.getInput("gate-mode") || "threshold").toLowerCase();
+  if (!GATE_MODES.includes(raw as GateMode)) {
+    throw new Error(
+      `Invalid gate-mode "${raw}". Expected one of: ${GATE_MODES.join(", ")}.`,
+    );
+  }
+  return raw as GateMode;
+}
+
 export function getInputs(): ActionInputs {
   const lcovFile = core.getInput("lcov-file") || "coverage/lcov.info";
   const coverageThreshold = core.getInput("coverage-threshold") || "80";
+  const gateMode = parseGateMode();
   const targetBranch = core.getInput("target-branch") || "main";
   const githubToken = core.getInput("github-token", { required: true });
   const label = optionalInput("label");
@@ -32,6 +47,7 @@ export function getInputs(): ActionInputs {
   return {
     lcovFile,
     coverageThreshold,
+    gateMode,
     targetBranch,
     githubToken,
     label,
@@ -46,6 +62,7 @@ export function getInputs(): ActionInputs {
 export function printInputs(inputs: ActionInputs): void {
   core.info(`📁 LCOV file: ${inputs.lcovFile}`);
   core.info(`📊 Coverage threshold: ${inputs.coverageThreshold}%`);
+  core.info(`🚦 Gate mode: ${inputs.gateMode}`);
   core.info(`🌿 Target branch: ${inputs.targetBranch}`);
   core.info(
     `🔑 GitHub token: ${inputs.githubToken ? "[PROVIDED]" : "[MISSING]"}`,

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -22,7 +22,7 @@ function optionalInput(name: string): string | undefined {
 }
 
 function parseGateMode(): GateMode {
-  const raw = (core.getInput("gate-mode") || "baseline").trim().toLowerCase();
+  const raw = (core.getInput("gate-mode") || "threshold").trim().toLowerCase();
   if (!GATE_MODES.includes(raw as GateMode)) {
     throw new Error(
       `Invalid gate-mode "${raw}". Expected one of: ${GATE_MODES.join(", ")}.`,

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -22,7 +22,7 @@ function optionalInput(name: string): string | undefined {
 }
 
 function parseGateMode(): GateMode {
-  const raw = (core.getInput("gate-mode") || "threshold").toLowerCase();
+  const raw = (core.getInput("gate-mode") || "baseline").trim().toLowerCase();
   if (!GATE_MODES.includes(raw as GateMode)) {
     throw new Error(
       `Invalid gate-mode "${raw}". Expected one of: ${GATE_MODES.join(", ")}.`,

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -262,6 +262,7 @@ describe("analyzeCoverageAndGating", () => {
     const result = await analyzeCoverageAndGating(
       mockChangeset,
       mockLcovReport,
+      "threshold",
       80,
     );
 
@@ -276,6 +277,7 @@ describe("analyzeCoverageAndGating", () => {
     expect(mockedCoverageGating.evaluate).toHaveBeenCalledWith(
       mockAnalysis,
       mockLcovReport,
+      "threshold",
       80,
     );
     expect(mockedCore.info).toHaveBeenCalledWith("Gating formatted");

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -9,8 +9,8 @@ import { CoverageGating, GatingResult } from "./coverageGating";
 import { TreemapGenerator } from "./treemap/treemapGenerator";
 import { ArtifactService, ArtifactInfo } from "./artifactService";
 import { ChecksService } from "./checksService";
+import { GateMode } from "./inputs";
 import { toErrorMessage } from "./errors";
-
 const TREEMAP_OUTPUT_PATH = "./coverage-treemap.png";
 const ARTIFACT_RETENTION_DAYS = 30;
 
@@ -67,6 +67,7 @@ export async function parseLcovReport(lcovFile: string): Promise<LcovReport> {
 export async function analyzeCoverageAndGating(
   changeset: Changeset,
   lcovReport: LcovReport,
+  gateMode: GateMode,
   threshold: number,
 ): Promise<{ analysis: CoverageAnalysis; gatingResult: GatingResult }> {
   return withGroup("🔍 Analyzing coverage for changed files", async () => {
@@ -77,6 +78,7 @@ export async function analyzeCoverageAndGating(
     const gatingResult = CoverageGating.evaluate(
       analysis,
       lcovReport,
+      gateMode,
       threshold,
     );
 

--- a/src/prComment.test.ts
+++ b/src/prComment.test.ts
@@ -317,6 +317,49 @@ describe("PrCommentService", () => {
       expect(result).toContain("| **Difference** | 📉 -20% | - |");
     });
 
+    test("should render an informational note when gating is disabled", () => {
+      const service = new PrCommentService({
+        githubToken: "test-token",
+      });
+
+      const commentData: CommentData = {
+        totalCoverage: { linesHit: 800, linesFound: 1000, percentage: 80 },
+        changedFilesCoverage: { linesHit: 10, linesFound: 50, percentage: 20 },
+        coverageDifference: -60,
+        fileBreakdown: [
+          {
+            filename: "src/example.ts",
+            linesHit: 10,
+            linesFound: 50,
+            percentage: 20,
+          },
+        ],
+      };
+
+      const gatingResult: GatingResult = {
+        meetsThreshold: true,
+        threshold: 80,
+        mode: "disabled",
+        prCoveragePercentage: 20,
+        overallProjectCoveragePercentage: 80,
+        description:
+          "ℹ️ Coverage gating disabled — PR coverage (20%) is not enforced",
+      };
+
+      const generateCommentBody = (
+        service as unknown as {
+          generateCommentBody: (
+            data: CommentData,
+            gatingResult: GatingResult,
+          ) => string;
+        }
+      ).generateCommentBody.bind(service);
+      const result = generateCommentBody(commentData, gatingResult);
+
+      expect(result).toContain("| **Threshold** | ℹ️ Gating disabled | - |");
+      expect(result).toContain("ℹ️ `src/example.ts` | 20% | 10/50");
+    });
+
     test("should handle threshold = 0 (compare against project average)", () => {
       const service = new PrCommentService({
         githubToken: "test-token",

--- a/src/prComment.ts
+++ b/src/prComment.ts
@@ -207,9 +207,11 @@ function buildCommentBody(
   const hasChangedLines = data.changedFilesCoverage.linesFound > 0;
 
   const thresholdDisplay =
-    gatingResult.mode === "baseline"
-      ? `≥ Project Avg (${gatingResult.overallProjectCoveragePercentage}%)`
-      : `${gatingResult.threshold}%`;
+    gatingResult.mode === "disabled"
+      ? "Gating disabled"
+      : gatingResult.mode === "baseline"
+        ? `≥ Project Avg (${gatingResult.overallProjectCoveragePercentage}%)`
+        : `${gatingResult.threshold}%`;
 
   const changedFilesCell = hasChangedLines
     ? `${data.changedFilesCoverage.percentage}% | ${formatLines(
@@ -228,9 +230,12 @@ function buildCommentBody(
       } ${data.coverageDifference > 0 ? "+" : ""}${data.coverageDifference}%`
     : `–`;
 
-  const thresholdCell = hasChangedLines
-    ? `${gatingResult.meetsThreshold ? "✅" : "❌"} ${thresholdDisplay}`
-    : `➖ ${thresholdDisplay} (no changed lines)`;
+  const thresholdCell =
+    gatingResult.mode === "disabled"
+      ? `ℹ️ ${thresholdDisplay}`
+      : hasChangedLines
+        ? `${gatingResult.meetsThreshold ? "✅" : "❌"} ${thresholdDisplay}`
+        : `➖ ${thresholdDisplay} (no changed lines)`;
 
   let markdown = `## ${title}\n\n`;
 
@@ -254,11 +259,16 @@ function buildCommentBody(
     markdown += `|------|----------|-------|\n`;
 
     for (const file of data.fileBreakdown) {
-      const fileThresholdMet =
-        gatingResult.mode === "baseline"
-          ? file.percentage >= gatingResult.overallProjectCoveragePercentage!
-          : file.percentage >= gatingResult.threshold;
-      const fileEmoji = fileThresholdMet ? "✅" : "❌";
+      let fileEmoji: string;
+      if (gatingResult.mode === "disabled") {
+        fileEmoji = "ℹ️";
+      } else {
+        const fileThresholdMet =
+          gatingResult.mode === "baseline"
+            ? file.percentage >= gatingResult.overallProjectCoveragePercentage!
+            : file.percentage >= gatingResult.threshold;
+        fileEmoji = fileThresholdMet ? "✅" : "❌";
+      }
       markdown += `| ${fileEmoji} \`${file.filename}\` | ${
         file.percentage
       }% | ${formatLines(file.linesHit, file.linesFound)} |\n`;


### PR DESCRIPTION
## Summary

Adds a new `gate-mode` enum input that explicitly selects how the action gates the workflow on coverage, including a new option to not gate at all — without the caller workflow having to flag the step to ignore failures.

`gate-mode` accepts:
- `threshold` (default) — fail when changed-files coverage is below `coverage-threshold`.
- `baseline` — fail when changed-files coverage is below the overall project coverage.
- `none` — never fail the workflow; coverage is measured and reported only.

### Notable behavior changes
- The previous "`coverage-threshold: 0` means baseline" magic is removed in favor of the explicit `gate-mode: baseline`. `coverage-threshold` is now only consulted in `threshold` mode.
- In `none` mode, `meets-threshold` is reported as `true` and the PR comment renders an informational "Gating disabled" note (per-file rows use ℹ️ instead of ✅/❌).
- Invalid `gate-mode` values fail fast with a clear error listing the accepted values.

### Files
- `action.yaml` / `README.md`: document the new input and modes.
- `inputs.ts`: parse/validate `gate-mode` (case-insensitive), add to `ActionInputs`.
- `coverageGating.ts`: take the mode, short-circuit to a non-gating result for `none`.
- `pipeline.ts` / `index.ts`: thread the mode through.
- `prComment.ts`: render the disabled state.

## Testing

- Added unit tests for `gate-mode` parsing (explicit value, case normalization, invalid-value error), the disabled gating evaluation/format path, and the disabled PR-comment rendering.
- Manually smoke-tested the rebuilt `dist/index.js` bundle to confirm it loads and reaches input parsing.