### PR TITLE
Add pr-comment toggle and job-summary report surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,7 @@ jobs:
         github-app-private-key: ${{ secrets.COVERAGEMAP_APP_PRIVATE_KEY }}
         source-code-pattern: "src/**/*.ts"
         test-code-pattern: "src/**/*.test.ts, src/__mocks__/**/*"
+        # Self-test the report surfaces: keep the PR comment and also write the
+        # coverage summary to the workflow run's job summary page.
+        pr-comment: "true"
+        job-summary: "true"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Multiple patterns can be specified by separating them with commas. Each file is 
 | `coverage-threshold`   | `string` | `false`  | `'80'`                 | Min coverage % for changed files. Only used when `gate-mode` is `threshold`.                                       |
 | `gate-mode`            | `string` | `false`  | `'threshold'`          | How to gate the workflow: `threshold` (fail below `coverage-threshold`), `baseline` (fail below overall project coverage), or `none` (never fail; report only). |
 | `github-token`         | `string` | `true`   | -                      | GitHub token to post PR comments                                                                                     |
+| `pr-comment`           | `string` | `false`  | `'true'`               | Whether to post and update the coverage summary comment on the PR. Set to `'false'` to avoid PR clutter.            |
+| `job-summary`          | `string` | `false`  | `'false'`              | Whether to write the coverage summary to the [GitHub Actions job summary](https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary). |
 | `target-branch`        | `string` | `false`  | `'main'`               | Branch the PR targets. Used only for labelling/reporting; the diff base is derived from the PR event (see [Changeset Detection](#changeset-detection)). |
 | `label`                | `string` | `false`  | -                      | Optional label for comment identification                                                                             |
 | `source-code-pattern`  | `string` | `false`  | -                      | Optional glob pattern(s) for source code files to include in coverage analysis. Multiple patterns separated by commas. |
@@ -161,6 +163,15 @@ This mode ensures new code doesn't lower the overall quality bar while allowing 
 The action measures and reports coverage but never fails the workflow. Use this to surface the treemap and PR comment without enforcing a gate, instead of having the caller workflow flag the step to ignore failures.
 
   - ℹ️ **Always passes**: `meets-threshold` is reported as `true` and the PR comment shows a "Gating disabled" note.
+
+## Report Surfaces
+
+The coverage summary can be surfaced in two places, controlled independently:
+
+  - **PR comment** (`pr-comment`, default `true`): posts a single comment on the pull request and updates it on subsequent runs. Set `pr-comment: 'false'` to suppress it and keep the PR free of clutter.
+  - **Job summary** (`job-summary`, default `false`): writes the same report to the workflow run's [job summary](https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) page. Set `job-summary: 'true'` to enable it.
+
+Both surfaces render identical markdown, so you can disable the PR comment and rely on the job summary alone, or enable both.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ The coverage summary can be surfaced in two places, controlled independently:
 
 Both surfaces render identical markdown, so you can disable the PR comment and rely on the job summary alone, or enable both.
 
+When the [GitHub Checks API integration](#github-checks-api-integration) is enabled, both surfaces also link to the check run so reviewers can jump straight to the inline, line-level coverage annotations.
+
 ## Outputs
 
 | Name                | Type      | Description                                      |

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,19 @@ inputs:
   github-token:
     description: GitHub token to post PR comments
     required: true
+  pr-comment:
+    description: |
+      Whether to post (and update) a coverage summary comment on the pull request.
+      Set to "false" to suppress the PR comment and avoid cluttering the PR.
+    required: false
+    default: "true"
+  job-summary:
+    description: |
+      Whether to write the coverage summary to the GitHub Actions job summary.
+      Enabled with "true" to surface coverage on the workflow run page without
+      posting a PR comment.
+    required: false
+    default: "false"
   label:
     description: |
       Optional label for identification (enables multiple instances).

--- a/src/checksService.test.ts
+++ b/src/checksService.test.ts
@@ -898,12 +898,13 @@ describe("ChecksService", () => {
         data: { html_url: "https://github.com/owner/repo/runs/123" },
       });
 
-      await checksService.postAnnotations(
+      const checkRunUrl = await checksService.postAnnotations(
         analysis,
         createMockGatingResult(),
         annotations,
       );
 
+      expect(checkRunUrl).toBe("https://github.com/owner/repo/runs/123");
       expect(mockedCreateAppAuth).toHaveBeenCalledWith({
         appId: "123456",
         privateKey:

--- a/src/checksService.ts
+++ b/src/checksService.ts
@@ -207,12 +207,12 @@ export class ChecksService {
     gatingResult: GatingResult,
     annotations: CheckAnnotation[],
     _prCommentUrl?: string,
-  ): Promise<void> {
+  ): Promise<string | null> {
     if (!github.context.payload.pull_request) {
       core.warning(
         "Not running in a pull request context, skipping check annotations",
       );
-      return;
+      return null;
     }
 
     try {
@@ -272,6 +272,8 @@ export class ChecksService {
 
       core.info(`✅ Posted ${annotations.length} annotations to GitHub Checks`);
       core.info(`🔗 Check run: ${createCheckResponse.data.html_url}`);
+
+      return createCheckResponse.data.html_url;
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -178,4 +178,44 @@ describe("run", () => {
 
     expect(mockedCore.setFailed).toHaveBeenCalledWith("String error");
   });
+
+  it("should skip the PR comment when pr-comment is disabled", async () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === "github-token") return "test-token";
+      if (name === "lcov-file") return "coverage/lcov.info";
+      if (name === "coverage-threshold") return "80";
+      if (name === "target-branch") return "main";
+      if (name === "pr-comment") return "false";
+      return "";
+    });
+
+    await run();
+
+    expect(mockedPrCommentService).not.toHaveBeenCalled();
+    expect(mockedCore.setFailed).not.toHaveBeenCalled();
+  });
+
+  it("should write the job summary when job-summary is enabled", async () => {
+    const writeMock = mockedCore.summary.write as unknown as jest.Mock;
+    const addRawMock = mockedCore.summary.addRaw as unknown as jest.Mock;
+    writeMock.mockResolvedValue(undefined);
+    addRawMock.mockReturnValue(mockedCore.summary);
+    (mockedCore.summary.addEOL as unknown as jest.Mock).mockReturnValue(
+      mockedCore.summary,
+    );
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === "github-token") return "test-token";
+      if (name === "lcov-file") return "coverage/lcov.info";
+      if (name === "coverage-threshold") return "80";
+      if (name === "target-branch") return "main";
+      if (name === "job-summary") return "true";
+      return "";
+    });
+
+    await run();
+
+    expect(addRawMock).toHaveBeenCalled();
+    expect(writeMock).toHaveBeenCalled();
+    expect(mockedCore.setFailed).not.toHaveBeenCalled();
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   analyzeCoverageAndGating,
   generateAndUploadTreemap,
   postPrComment,
+  writeJobSummary,
   postCheckAnnotations,
 } from "./pipeline";
 import { toErrorMessage } from "./errors";
@@ -35,14 +36,26 @@ export async function run(): Promise<void> {
       inputs.treemapTitle,
     );
 
-    const prCommentUrl = await postPrComment(
-      analysis,
-      lcovReport,
-      gatingResult,
-      inputs.githubToken,
-      inputs.label,
-      treemapArtifact || undefined,
-    );
+    const prCommentUrl = inputs.prComment
+      ? await postPrComment(
+          analysis,
+          lcovReport,
+          gatingResult,
+          inputs.githubToken,
+          inputs.label,
+          treemapArtifact || undefined,
+        )
+      : null;
+
+    if (inputs.jobSummary) {
+      await writeJobSummary(
+        analysis,
+        lcovReport,
+        gatingResult,
+        inputs.label,
+        treemapArtifact || undefined,
+      );
+    }
 
     await postCheckAnnotations(
       analysis,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,16 +36,28 @@ export async function run(): Promise<void> {
       inputs.treemapTitle,
     );
 
-    const prCommentUrl = inputs.prComment
-      ? await postPrComment(
-          analysis,
-          lcovReport,
-          gatingResult,
-          inputs.githubToken,
-          inputs.label,
-          treemapArtifact || undefined,
-        )
-      : null;
+    const checkRunUrl = await postCheckAnnotations(
+      analysis,
+      gatingResult,
+      inputs.githubToken,
+      threshold,
+      inputs.githubAppId,
+      inputs.githubAppPrivateKey,
+      undefined,
+      inputs.label,
+    );
+
+    if (inputs.prComment) {
+      await postPrComment(
+        analysis,
+        lcovReport,
+        gatingResult,
+        inputs.githubToken,
+        inputs.label,
+        treemapArtifact || undefined,
+        checkRunUrl || undefined,
+      );
+    }
 
     if (inputs.jobSummary) {
       await writeJobSummary(
@@ -54,19 +66,9 @@ export async function run(): Promise<void> {
         gatingResult,
         inputs.label,
         treemapArtifact || undefined,
+        checkRunUrl || undefined,
       );
     }
-
-    await postCheckAnnotations(
-      analysis,
-      gatingResult,
-      inputs.githubToken,
-      threshold,
-      inputs.githubAppId,
-      inputs.githubAppPrivateKey,
-      prCommentUrl || undefined,
-      inputs.label,
-    );
 
     if (!gatingResult.meetsThreshold) {
       core.setFailed(

--- a/src/inputs.test.ts
+++ b/src/inputs.test.ts
@@ -30,6 +30,8 @@ describe("getInputs", () => {
       gateMode: "threshold",
       targetBranch: "baz",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
       label: "test-label",
       sourceCodePattern: "src/**/*.ts",
       testCodePattern: "**/*.test.ts",
@@ -59,6 +61,8 @@ describe("getInputs", () => {
       gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
       label: undefined,
       sourceCodePattern: undefined,
       testCodePattern: undefined,
@@ -83,6 +87,8 @@ describe("getInputs", () => {
       gateMode: "threshold",
       targetBranch: "develop",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
       label: undefined,
       sourceCodePattern: undefined,
       testCodePattern: undefined,
@@ -107,6 +113,8 @@ describe("getInputs", () => {
       gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
       label: undefined,
       sourceCodePattern: undefined,
       testCodePattern: undefined,
@@ -131,6 +139,8 @@ describe("getInputs", () => {
       gateMode: "threshold",
       targetBranch: "develop",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
       label: undefined,
       sourceCodePattern: undefined,
       testCodePattern: undefined,
@@ -153,6 +163,8 @@ describe("getInputs", () => {
       gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
       label: undefined,
       sourceCodePattern: "src/**/*.ts,lib/**/*.js",
       testCodePattern: "**/*.test.*,**/*.spec.*",
@@ -175,6 +187,8 @@ describe("getInputs", () => {
       gateMode: "threshold",
       targetBranch: "main",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
       label: undefined,
       sourceCodePattern: "app/**/*.py",
       testCodePattern: undefined,
@@ -199,6 +213,44 @@ describe("getInputs", () => {
     });
 
     expect(getInputs().gateMode).toBe("none");
+  });
+
+  it("should default pr-comment on and job-summary off", () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === "github-token") return "test-token";
+      return "";
+    });
+
+    const result = getInputs();
+
+    expect(result.prComment).toBe(true);
+    expect(result.jobSummary).toBe(false);
+  });
+
+  it("should disable the pr-comment and enable the job-summary", () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === "github-token") return "test-token";
+      if (name === "pr-comment") return "false";
+      if (name === "job-summary") return "true";
+      return "";
+    });
+
+    const result = getInputs();
+
+    expect(result.prComment).toBe(false);
+    expect(result.jobSummary).toBe(true);
+  });
+
+  it("should throw on a non-boolean pr-comment", () => {
+    mockedCore.getInput.mockImplementation((name: string) => {
+      if (name === "github-token") return "test-token";
+      if (name === "pr-comment") return "maybe";
+      return "";
+    });
+
+    expect(() => getInputs()).toThrow(
+      /Input does not meet YAML 1.2 "Core Schema" specification: pr-comment/,
+    );
   });
 
   it("should throw on an invalid gate-mode", () => {
@@ -226,6 +278,8 @@ describe("printInputs", () => {
       gateMode: "threshold" as const,
       targetBranch: "main",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
       label: "coverage",
       sourceCodePattern: "src/**/*.ts",
       testCodePattern: "**/*.test.ts",
@@ -240,6 +294,8 @@ describe("printInputs", () => {
     expect(mockedCore.info).toHaveBeenCalledWith("🚦 Gate mode: threshold");
     expect(mockedCore.info).toHaveBeenCalledWith("🌿 Target branch: main");
     expect(mockedCore.info).toHaveBeenCalledWith("🔑 GitHub token: [PROVIDED]");
+    expect(mockedCore.info).toHaveBeenCalledWith("💬 PR comment: enabled");
+    expect(mockedCore.info).toHaveBeenCalledWith("📝 Job summary: disabled");
     expect(mockedCore.info).toHaveBeenCalledWith("🏷️ Label: coverage");
     expect(mockedCore.info).toHaveBeenCalledWith(
       "📂 Source code pattern: src/**/*.ts",
@@ -256,6 +312,8 @@ describe("printInputs", () => {
       gateMode: "threshold" as const,
       targetBranch: "main",
       githubToken: "test-token",
+      prComment: true,
+      jobSummary: false,
     };
 
     printInputs(inputs);
@@ -284,6 +342,8 @@ describe("printInputs", () => {
       gateMode: "threshold" as const,
       targetBranch: "main",
       githubToken: "",
+      prComment: true,
+      jobSummary: false,
     };
 
     printInputs(inputs);

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -9,6 +9,8 @@ export interface ActionInputs {
   gateMode: GateMode;
   targetBranch: string;
   githubToken: string;
+  prComment: boolean;
+  jobSummary: boolean;
   label?: string;
   sourceCodePattern?: string;
   testCodePattern?: string;
@@ -19,6 +21,28 @@ export interface ActionInputs {
 
 function optionalInput(name: string): string | undefined {
   return core.getInput(name) || undefined;
+}
+
+const TRUE_VALUES = ["true", "True", "TRUE"];
+const FALSE_VALUES = ["false", "False", "FALSE"];
+
+// Mirrors @actions/core.getBooleanInput's YAML 1.2 "Core Schema" handling but
+// falls back to a default when the input is absent so callers can omit it.
+function parseBooleanInput(name: string, defaultValue: boolean): boolean {
+  const raw = core.getInput(name);
+  if (raw === "") {
+    return defaultValue;
+  }
+  if (TRUE_VALUES.includes(raw)) {
+    return true;
+  }
+  if (FALSE_VALUES.includes(raw)) {
+    return false;
+  }
+  throw new TypeError(
+    `Input does not meet YAML 1.2 "Core Schema" specification: ${name}\n` +
+      "Support boolean input list: `true | True | TRUE | false | False | FALSE`",
+  );
 }
 
 function parseGateMode(): GateMode {
@@ -37,6 +61,8 @@ export function getInputs(): ActionInputs {
   const gateMode = parseGateMode();
   const targetBranch = core.getInput("target-branch") || "main";
   const githubToken = core.getInput("github-token", { required: true });
+  const prComment = parseBooleanInput("pr-comment", true);
+  const jobSummary = parseBooleanInput("job-summary", false);
   const label = optionalInput("label");
   const sourceCodePattern = optionalInput("source-code-pattern");
   const testCodePattern = optionalInput("test-code-pattern");
@@ -50,6 +76,8 @@ export function getInputs(): ActionInputs {
     gateMode,
     targetBranch,
     githubToken,
+    prComment,
+    jobSummary,
     label,
     sourceCodePattern,
     testCodePattern,
@@ -67,6 +95,8 @@ export function printInputs(inputs: ActionInputs): void {
   core.info(
     `🔑 GitHub token: ${inputs.githubToken ? "[PROVIDED]" : "[MISSING]"}`,
   );
+  core.info(`💬 PR comment: ${inputs.prComment ? "enabled" : "disabled"}`);
+  core.info(`📝 Job summary: ${inputs.jobSummary ? "enabled" : "disabled"}`);
   if (inputs.label) {
     core.info(`🏷️ Label: ${inputs.label}`);
   }

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -377,6 +377,7 @@ describe("postPrComment", () => {
       mockLcovReport,
       mockGatingResult,
       undefined,
+      undefined,
     );
     expect(mockedCore.info).toHaveBeenCalledWith(
       "✅ PR comment posted successfully",

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -603,7 +603,7 @@ describe("writeJobSummary", () => {
       mockAnalysis,
       mockLcovReport,
       mockGatingResult,
-      { label: "coverage", treemapArtifact: undefined },
+      { label: "coverage", treemapArtifact: undefined, checkRunUrl: undefined },
     );
     expect(addRawMock).toHaveBeenCalledWith("## Coverage body");
     expect(writeMock).toHaveBeenCalled();

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -52,13 +52,14 @@ import {
   parseLcovReport,
   analyzeCoverageAndGating,
   postPrComment,
+  writeJobSummary,
   generateAndUploadTreemap,
   buildTreemapSubtitle,
 } from "./pipeline";
 import { ChangesetService } from "./changesetService";
 import { LcovParser } from "./lcov";
 import { CoverageAnalyzer } from "./coverageAnalyzer";
-import { PrCommentService } from "./prComment";
+import { PrCommentService, renderCoverageReport } from "./prComment";
 import { CoverageGating } from "./coverageGating";
 import { ArtifactService } from "./artifactService";
 
@@ -82,6 +83,9 @@ const mockedCoverageAnalyzer = CoverageAnalyzer as jest.Mocked<
 >;
 const mockedPrCommentService = PrCommentService as jest.MockedClass<
   typeof PrCommentService
+>;
+const mockedRenderCoverageReport = renderCoverageReport as jest.MockedFunction<
+  typeof renderCoverageReport
 >;
 const mockedCoverageGating = CoverageGating as jest.Mocked<
   typeof CoverageGating
@@ -512,6 +516,112 @@ describe("postPrComment", () => {
     expect(mockedCore.warning).toHaveBeenCalledWith(
       "Failed to post PR comment: String error",
     );
+  });
+});
+
+describe("writeJobSummary", () => {
+  const mockAnalysis = {
+    changeset: {
+      baseCommit: "abc123",
+      headCommit: "def456",
+      targetBranch: "main",
+      files: [],
+      totalFiles: 0,
+    },
+    changedFiles: [],
+    summary: {
+      totalChangedFiles: 1,
+      filesWithCoverage: 1,
+      filesWithoutCoverage: 0,
+      overallCoverage: {
+        overallCoveragePercentage: 85.5,
+        totalLines: 100,
+        coveredLines: 85,
+        totalFunctions: 20,
+        coveredFunctions: 18,
+        totalBranches: 10,
+        coveredBranches: 8,
+        linesCoveragePercentage: 85.0,
+        functionsCoveragePercentage: 90.0,
+        branchesCoveragePercentage: 80.0,
+      },
+    },
+  };
+  const mockLcovReport = {
+    files: new Map(),
+    summary: {
+      totalFiles: 5,
+      linesFound: 100,
+      linesHit: 80,
+      functionsFound: 20,
+      functionsHit: 18,
+      branchesFound: 10,
+      branchesHit: 8,
+    },
+  };
+  const mockGatingResult = {
+    meetsThreshold: true,
+    threshold: 80,
+    mode: "standard" as const,
+    prCoveragePercentage: 85.5,
+    description: "Coverage meets threshold",
+  };
+
+  let writeMock: jest.Mock;
+  let addRawMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // @actions/core is auto-mocked, so core.summary already exists with mocked
+    // methods. Wire the chain (addRaw -> addEOL -> write) to return the summary
+    // and resolve on write.
+    writeMock = mockedCore.summary.write as unknown as jest.Mock;
+    addRawMock = mockedCore.summary.addRaw as unknown as jest.Mock;
+    writeMock.mockResolvedValue(undefined);
+    addRawMock.mockReturnValue(mockedCore.summary);
+    (mockedCore.summary.addEOL as unknown as jest.Mock).mockReturnValue(
+      mockedCore.summary,
+    );
+  });
+
+  it("should render the report and write it to the job summary", async () => {
+    mockedRenderCoverageReport.mockReturnValue("## Coverage body");
+
+    await writeJobSummary(
+      mockAnalysis,
+      mockLcovReport,
+      mockGatingResult,
+      "coverage",
+      undefined,
+    );
+
+    expect(mockedCore.startGroup).toHaveBeenCalledWith(
+      "📝 Writing job summary",
+    );
+    expect(mockedRenderCoverageReport).toHaveBeenCalledWith(
+      mockAnalysis,
+      mockLcovReport,
+      mockGatingResult,
+      { label: "coverage", treemapArtifact: undefined },
+    );
+    expect(addRawMock).toHaveBeenCalledWith("## Coverage body");
+    expect(writeMock).toHaveBeenCalled();
+    expect(mockedCore.info).toHaveBeenCalledWith(
+      "✅ Job summary written successfully",
+    );
+    expect(mockedCore.endGroup).toHaveBeenCalled();
+  });
+
+  it("should warn when writing the job summary fails", async () => {
+    mockedRenderCoverageReport.mockReturnValue("## Coverage body");
+    writeMock.mockRejectedValue(new Error("disk full"));
+
+    await writeJobSummary(mockAnalysis, mockLcovReport, mockGatingResult);
+
+    expect(mockedCore.warning).toHaveBeenCalledWith(
+      "Failed to write job summary: disk full",
+    );
+    expect(mockedCore.endGroup).toHaveBeenCalled();
   });
 });
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -4,7 +4,7 @@ import { ChangesetService } from "./changesetService";
 import { LcovParser, LcovReport } from "./lcov";
 import { CoverageAnalyzer, CoverageAnalysis } from "./coverageAnalyzer";
 import { Changeset } from "./changeset";
-import { PrCommentService } from "./prComment";
+import { PrCommentService, renderCoverageReport } from "./prComment";
 import { CoverageGating, GatingResult } from "./coverageGating";
 import { TreemapGenerator } from "./treemap/treemapGenerator";
 import { ArtifactService, ArtifactInfo } from "./artifactService";
@@ -186,6 +186,29 @@ export async function postPrComment(
         "🔍 This might be because the action is not running in a PR context or lacks permissions",
       );
       return null;
+    }
+  });
+}
+
+export async function writeJobSummary(
+  analysis: CoverageAnalysis,
+  lcovReport: LcovReport,
+  gatingResult: GatingResult,
+  label?: string,
+  treemapArtifact?: ArtifactInfo,
+): Promise<void> {
+  return withGroup("📝 Writing job summary", async () => {
+    try {
+      const body = renderCoverageReport(analysis, lcovReport, gatingResult, {
+        label,
+        treemapArtifact,
+      });
+
+      await core.summary.addRaw(body).addEOL().write();
+
+      core.info("✅ Job summary written successfully");
+    } catch (error) {
+      core.warning(`Failed to write job summary: ${toErrorMessage(error)}`);
     }
   });
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -160,6 +160,7 @@ export async function postPrComment(
   githubToken: string,
   label?: string,
   treemapArtifact?: ArtifactInfo,
+  checkRunUrl?: string,
 ): Promise<string | null> {
   return withGroup("💬 Posting PR comment", async () => {
     try {
@@ -173,6 +174,7 @@ export async function postPrComment(
         lcovReport,
         gatingResult,
         treemapArtifact,
+        checkRunUrl,
       );
 
       core.info("✅ PR comment posted successfully");
@@ -196,12 +198,14 @@ export async function writeJobSummary(
   gatingResult: GatingResult,
   label?: string,
   treemapArtifact?: ArtifactInfo,
+  checkRunUrl?: string,
 ): Promise<void> {
   return withGroup("📝 Writing job summary", async () => {
     try {
       const body = renderCoverageReport(analysis, lcovReport, gatingResult, {
         label,
         treemapArtifact,
+        checkRunUrl,
       });
 
       await core.summary.addRaw(body).addEOL().write();
@@ -222,12 +226,12 @@ export async function postCheckAnnotations(
   githubAppPrivateKey?: string,
   prCommentUrl?: string,
   label?: string,
-): Promise<void> {
+): Promise<string | null> {
   if (!ChecksService.isEnabled(githubAppId, githubAppPrivateKey)) {
     core.info(
       "⏭️ Skipping check annotations - GitHub App credentials not provided",
     );
-    return;
+    return null;
   }
 
   return withGroup("📝 Posting check annotations", async () => {
@@ -244,7 +248,7 @@ export async function postCheckAnnotations(
 
       if (annotations.length === 0) {
         core.info("ℹ️ No annotations to post - all files have good coverage");
-        return;
+        return null;
       }
 
       const annotationsPath =
@@ -258,7 +262,7 @@ export async function postCheckAnnotations(
         ARTIFACT_RETENTION_DAYS,
       );
 
-      await checksService.postAnnotations(
+      const checkRunUrl = await checksService.postAnnotations(
         analysis,
         gatingResult,
         annotations,
@@ -270,6 +274,8 @@ export async function postCheckAnnotations(
       core.info(
         `✅ Posted ${annotations.length} check annotations successfully`,
       );
+
+      return checkRunUrl;
     } catch (error) {
       core.warning(
         `Failed to post check annotations: ${toErrorMessage(error)}`,
@@ -277,6 +283,7 @@ export async function postCheckAnnotations(
       core.info(
         "🔍 This might be because the action lacks permissions for the Checks API or GitHub App is not properly configured",
       );
+      return null;
     }
   });
 }

--- a/src/prComment.test.ts
+++ b/src/prComment.test.ts
@@ -1019,4 +1019,28 @@ describe("renderCoverageReport", () => {
     expect(result).toContain("### 📊 Coverage Treemap Visualization");
     expect(result).toContain("coverage-treemap-pr-123");
   });
+
+  test("includes the check annotations link when a check run URL is provided", () => {
+    const result = renderCoverageReport(
+      mockAnalysis,
+      mockLcovReport,
+      gatingResult,
+      { checkRunUrl: "https://github.com/owner/repo/runs/123" },
+    );
+
+    expect(result).toContain("### 🔍 Inline Coverage Annotations");
+    expect(result).toContain(
+      "[Coverage Treemap Action check](https://github.com/owner/repo/runs/123)",
+    );
+  });
+
+  test("omits the check annotations section when no check run URL is provided", () => {
+    const result = renderCoverageReport(
+      mockAnalysis,
+      mockLcovReport,
+      gatingResult,
+    );
+
+    expect(result).not.toContain("### 🔍 Inline Coverage Annotations");
+  });
 });

--- a/src/prComment.test.ts
+++ b/src/prComment.test.ts
@@ -2,6 +2,8 @@ import {
   PrCommentService,
   CommentData,
   generateCommentBody,
+  renderCoverageReport,
+  buildReportTitle,
   formatFileSize,
   formatLineCount,
 } from "./prComment";
@@ -882,5 +884,139 @@ describe("PrCommentService", () => {
         ),
       ).rejects.toThrow("Failed to post PR comment: API Error");
     });
+  });
+});
+
+describe("buildReportTitle", () => {
+  test("returns the bare title when no label is provided", () => {
+    expect(buildReportTitle()).toBe("Coveragemap Action");
+  });
+
+  test("appends the label when provided", () => {
+    expect(buildReportTitle("backend")).toBe("Coveragemap Action: backend");
+  });
+});
+
+describe("renderCoverageReport", () => {
+  const mockLcovReport: LcovReport = {
+    files: new Map(),
+    summary: {
+      totalFiles: 5,
+      linesFound: 1000,
+      linesHit: 800,
+      functionsFound: 100,
+      functionsHit: 85,
+      branchesFound: 50,
+      branchesHit: 40,
+    },
+  };
+
+  const mockAnalysis: CoverageAnalysis = {
+    changeset: {
+      baseCommit: "abc123",
+      headCommit: "def456",
+      targetBranch: "main",
+      files: [{ path: "src/example.ts", status: "modified" }],
+      totalFiles: 1,
+    },
+    changedFiles: [
+      {
+        path: "src/example.ts",
+        status: "modified",
+        coverage: {
+          path: "src/example.ts",
+          summary: {
+            linesFound: 50,
+            linesHit: 40,
+            functionsFound: 5,
+            functionsHit: 4,
+            branchesFound: 10,
+            branchesHit: 8,
+          },
+          lines: [],
+          functions: [],
+          branches: [],
+        },
+        analysis: {
+          totalLines: 50,
+          coveredLines: 40,
+          totalFunctions: 5,
+          coveredFunctions: 4,
+          totalBranches: 10,
+          coveredBranches: 8,
+          linesCoveragePercentage: 80,
+          functionsCoveragePercentage: 80,
+          branchesCoveragePercentage: 80,
+          overallCoveragePercentage: 80,
+        },
+      },
+    ],
+    summary: {
+      totalChangedFiles: 1,
+      filesWithCoverage: 1,
+      filesWithoutCoverage: 0,
+      overallCoverage: {
+        totalLines: 50,
+        coveredLines: 40,
+        totalFunctions: 5,
+        coveredFunctions: 4,
+        totalBranches: 10,
+        coveredBranches: 8,
+        linesCoveragePercentage: 80,
+        functionsCoveragePercentage: 80,
+        branchesCoveragePercentage: 80,
+        overallCoveragePercentage: 80,
+      },
+    },
+  };
+
+  const gatingResult: GatingResult = {
+    meetsThreshold: true,
+    threshold: 80,
+    mode: "standard",
+    prCoveragePercentage: 80,
+    description: "Coverage meets threshold",
+  };
+
+  test("renders the same markdown the PR comment uses, with the default title", () => {
+    const result = renderCoverageReport(
+      mockAnalysis,
+      mockLcovReport,
+      gatingResult,
+    );
+
+    expect(result).toContain("## Coveragemap Action");
+    expect(result).toContain("| **Total Coverage** | 80% | 800/1,000 |");
+    expect(result).toContain("✅ `src/example.ts` | 80% | 40/50");
+  });
+
+  test("applies the label to the title when provided", () => {
+    const result = renderCoverageReport(
+      mockAnalysis,
+      mockLcovReport,
+      gatingResult,
+      { label: "backend" },
+    );
+
+    expect(result).toContain("## Coveragemap Action: backend");
+  });
+
+  test("includes the treemap section when an artifact is provided", () => {
+    const result = renderCoverageReport(
+      mockAnalysis,
+      mockLcovReport,
+      gatingResult,
+      {
+        treemapArtifact: {
+          name: "coverage-treemap-pr-123",
+          path: "./coverage-treemap.png",
+          downloadUrl: "https://example.com/treemap",
+          size: 2048,
+        },
+      },
+    );
+
+    expect(result).toContain("### 📊 Coverage Treemap Visualization");
+    expect(result).toContain("coverage-treemap-pr-123");
   });
 });

--- a/src/prComment.ts
+++ b/src/prComment.ts
@@ -95,12 +95,14 @@ export class PrCommentService {
     data: CommentData,
     gatingResult: GatingResult,
     treemapArtifact?: ArtifactInfo,
+    checkRunUrl?: string,
   ): string {
     return buildCommentBody(
       this.getCommentTitle(),
       data,
       gatingResult,
       treemapArtifact,
+      checkRunUrl,
     );
   }
 
@@ -133,6 +135,7 @@ export class PrCommentService {
     lcovReport: LcovReport,
     gatingResult: GatingResult,
     treemapArtifact?: ArtifactInfo,
+    checkRunUrl?: string,
   ): Promise<string | null> {
     const { context } = github;
 
@@ -141,7 +144,12 @@ export class PrCommentService {
     }
 
     const data = PrCommentService.createCommentData(analysis, lcovReport);
-    const body = this.generateCommentBody(data, gatingResult, treemapArtifact);
+    const body = this.generateCommentBody(
+      data,
+      gatingResult,
+      treemapArtifact,
+      checkRunUrl,
+    );
 
     try {
       const existingCommentId = await this.findExistingComment();
@@ -207,7 +215,11 @@ export function renderCoverageReport(
   analysis: CoverageAnalysis,
   lcovReport: LcovReport,
   gatingResult: GatingResult,
-  options?: { label?: string; treemapArtifact?: ArtifactInfo },
+  options?: {
+    label?: string;
+    treemapArtifact?: ArtifactInfo;
+    checkRunUrl?: string;
+  },
 ): string {
   const data = PrCommentService.createCommentData(analysis, lcovReport);
   return buildCommentBody(
@@ -215,6 +227,7 @@ export function renderCoverageReport(
     data,
     gatingResult,
     options?.treemapArtifact,
+    options?.checkRunUrl,
   );
 }
 
@@ -228,6 +241,7 @@ function buildCommentBody(
   data: CommentData,
   gatingResult: GatingResult,
   treemapArtifact?: ArtifactInfo,
+  checkRunUrl?: string,
 ): string {
   // When the PR touches no lines that carry coverage data there is nothing
   // to compare, so we render placeholders instead of a misleading 100% /
@@ -319,6 +333,13 @@ function buildCommentBody(
       ? "direct download"
       : "Actions tab";
     markdown += `> 📥 **[Download treemap visualization](${downloadUrl})** - Click for ${linkText}\n\n`;
+  }
+
+  // Link to the check run so reviewers can jump to the inline coverage
+  // annotations when the Checks integration is enabled.
+  if (checkRunUrl) {
+    markdown += `### 🔍 Inline Coverage Annotations\n\n`;
+    markdown += `Line-level coverage annotations are available on the [Coverage Treemap Action check](${checkRunUrl}).\n\n`;
   }
 
   // Footer

--- a/src/prComment.ts
+++ b/src/prComment.ts
@@ -44,9 +44,7 @@ export class PrCommentService {
   }
 
   private getCommentTitle(): string {
-    return this.label
-      ? `Coveragemap Action: ${this.label}`
-      : "Coveragemap Action";
+    return buildReportTitle(this.label);
   }
 
   static createCommentData(
@@ -191,6 +189,34 @@ export class PrCommentService {
 }
 
 const PR_COMMENT_TITLE = "Coveragemap Action";
+
+/**
+ * Build the report title, optionally suffixed with a label so multiple action
+ * instances render distinct headings. Shared by the PR comment and the job
+ * summary so both stay in sync.
+ */
+export function buildReportTitle(label?: string): string {
+  return label ? `${PR_COMMENT_TITLE}: ${label}` : PR_COMMENT_TITLE;
+}
+
+/**
+ * Render the full coverage report markdown from analysis data. Reused by the
+ * PR comment and the GitHub job summary so both surfaces share one renderer.
+ */
+export function renderCoverageReport(
+  analysis: CoverageAnalysis,
+  lcovReport: LcovReport,
+  gatingResult: GatingResult,
+  options?: { label?: string; treemapArtifact?: ArtifactInfo },
+): string {
+  const data = PrCommentService.createCommentData(analysis, lcovReport);
+  return buildCommentBody(
+    buildReportTitle(options?.label),
+    data,
+    gatingResult,
+    options?.treemapArtifact,
+  );
+}
 
 /**
  * Build the markdown body for a coverage PR comment. Pure function shared by


### PR DESCRIPTION
## Summary

Adds two independent controls for where the coverage report is surfaced, so users can avoid PR clutter:

- **`pr-comment`** (default `true`): toggles the existing PR comment. Set to `false` to suppress the comment/update flow entirely.
- **`job-summary`** (default `false`): writes the same coverage report to the GitHub Actions job summary page when enabled.

Both surfaces share one renderer (`renderCoverageReport`) so their markdown stays identical. The repo's own CI self-test now enables both so the features are exercised on every PR.

## Changes

- `action.yaml`: new `pr-comment` and `job-summary` inputs with defaults.
- `inputs.ts`: parse both as booleans (YAML 1.2 Core Schema, default-aware) and log them.
- `prComment.ts`: extract `buildReportTitle()` and `renderCoverageReport()` so the body is reusable.
- `pipeline.ts`: new `writeJobSummary()` step (writes via `core.summary`).
- `index.ts`: post the PR comment only when `pr-comment` is enabled; write the job summary when `job-summary` is enabled.
- `.github/workflows/ci.yml`: enable `pr-comment` and `job-summary` in the self-test.
- README: document the new inputs and a "Report Surfaces" section.

## Testing

- Manually smoke-tested the rebuilt bundle (`node dist/index.js`) to confirm it still reaches input parsing.
- Considered edge cases: invalid boolean values now throw a clear Core Schema error; PR comment disabled means `prCommentUrl` is `null` and check annotations still work; job-summary failures are caught and downgraded to a warning rather than failing the run.
