### PR TITLE
Count only coverable lines for per-function treemap tiles

### DIFF
--- a/src/treemap/treemapData.test.ts
+++ b/src/treemap/treemapData.test.ts
@@ -526,4 +526,97 @@ describe("generateTreemapData", () => {
       expect(result.children[0].children[0].coverage).toBe(expected);
     },
   );
+
+  it("counts only coverable lines, ignoring interleaved type definitions", () => {
+    // Mirrors a TypeScript module whose functions are separated by type
+    // definitions, interface members and JSDoc comments (lines 1-18 and 21-23
+    // below). Those lines never appear as LCOV `DA` records, so they must not
+    // inflate a function's denominator. Both functions are fully covered and
+    // should render as such even though they are far apart in the source.
+    const mockAnalysis: CoverageAnalysis = {
+      changeset: {
+        baseCommit: "abc123",
+        headCommit: "def456",
+        targetBranch: "main",
+        files: [],
+        totalFiles: 1,
+      },
+      changedFiles: [
+        {
+          path: "src/recorder.models.ts",
+          status: "modified",
+          coverage: {
+            path: "src/recorder.models.ts",
+            functions: [
+              { name: "normalizeState", line: 19, hit: 12 },
+              { name: "hasRecorderError", line: 24, hit: 3 },
+            ],
+            // Only executable lines are tracked. Line 4 is a module-level
+            // const; lines 20 and 25 are the two function bodies. The interface
+            // and type alias on lines 1-18 produce no DA records at all.
+            lines: [
+              { line: 4, hit: 3 },
+              { line: 20, hit: 12 },
+              { line: 25, hit: 3 },
+            ],
+            branches: [],
+            summary: {
+              functionsFound: 2,
+              functionsHit: 2,
+              linesFound: 3,
+              linesHit: 3,
+              branchesFound: 0,
+              branchesHit: 0,
+            },
+          },
+          analysis: {
+            totalLines: 3,
+            coveredLines: 3,
+            totalFunctions: 2,
+            coveredFunctions: 2,
+            totalBranches: 0,
+            coveredBranches: 0,
+            linesCoveragePercentage: 100,
+            functionsCoveragePercentage: 100,
+            branchesCoveragePercentage: 0,
+            overallCoveragePercentage: 100,
+          },
+        },
+      ],
+      summary: {
+        totalChangedFiles: 1,
+        filesWithCoverage: 1,
+        filesWithoutCoverage: 0,
+        overallCoverage: {
+          totalLines: 3,
+          coveredLines: 3,
+          totalFunctions: 2,
+          coveredFunctions: 2,
+          totalBranches: 0,
+          coveredBranches: 0,
+          linesCoveragePercentage: 100,
+          functionsCoveragePercentage: 100,
+          branchesCoveragePercentage: 0,
+          overallCoveragePercentage: 100,
+        },
+      },
+    };
+
+    const result = generateTreemapData(mockAnalysis);
+
+    const tiles = result.children[0].children;
+    const normalizeState = tiles.find((c) => c.name === "normalizeState");
+    const hasRecorderError = tiles.find((c) => c.name === "hasRecorderError");
+
+    // Each function owns exactly one coverable line, both of which are hit.
+    // Without the fix, normalizeState would span 5 lines (19->24) and the
+    // trailing hasRecorderError would span the 10-line fallback estimate.
+    expect(normalizeState?.lineCount).toBe(1);
+    expect(normalizeState?.coveredLines).toBe(1);
+    expect(normalizeState?.coverage).toBe("full");
+
+    expect(hasRecorderError?.lineCount).toBe(1);
+    expect(hasRecorderError?.coveredLines).toBe(1);
+    expect(hasRecorderError?.coverage).toBe("full");
+  });
 });

--- a/src/treemap/treemapData.ts
+++ b/src/treemap/treemapData.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { CoverageAnalysis, FileChangeWithCoverage } from "../coverageAnalyzer";
-import { FunctionCoverage, FileCoverage } from "../lcov";
+import { FunctionCoverage, FileCoverage, LineCoverage } from "../lcov";
 import {
   CoverageState,
   TreemapData,
@@ -13,11 +13,6 @@ import {
  * the renderer consumes. Each changed file becomes a group of function tiles,
  * or a single file-level tile when no per-function data exists.
  */
-
-// Fallback line count when a function's span cannot be derived from the report.
-const DEFAULT_FUNCTION_LINE_COUNT = 10;
-// Minimum span assumed for the last function in a file, past its start line.
-const MIN_FUNCTION_SIZE_ESTIMATE = 10;
 
 export function generateTreemapData(analysis: CoverageAnalysis): TreemapData {
   return {
@@ -112,44 +107,64 @@ function classifyCoverage(covered: number, total: number): CoverageState {
 }
 
 /**
- * Estimate the number of lines a function spans. The range runs from the
- * function's declaration to the next function's declaration; the last function
- * in a file is estimated from the highest recorded line number.
+ * Resolve the half-open line span `[start, end)` attributed to a function: from
+ * its declaration line up to (but excluding) the next function's declaration.
+ * The last function in a file has no upper bound.
  */
-function getFunctionLineCount(
+function getFunctionLineRange(
   func: FunctionCoverage,
   fileCoverage: FileCoverage,
-): number {
+): { startLine: number; endLine: number } {
   const functions = [...fileCoverage.functions].sort((a, b) => a.line - b.line);
   const funcIndex = functions.findIndex(
     (f) => f.name === func.name && f.line === func.line,
   );
 
-  const currentFunc = funcIndex === -1 ? undefined : functions[funcIndex];
-  if (!currentFunc) return DEFAULT_FUNCTION_LINE_COUNT;
-
-  const nextFunc = functions[funcIndex + 1];
-  if (nextFunc) {
-    return Math.max(nextFunc.line - currentFunc.line, 1);
+  if (funcIndex === -1) {
+    return { startLine: func.line, endLine: func.line + 1 };
   }
 
-  // Last function - estimate based on file lines.
-  const maxLine = Math.max(
-    ...fileCoverage.lines.map((l) => l.line),
-    currentFunc.line + MIN_FUNCTION_SIZE_ESTIMATE,
-  );
-  return Math.max(maxLine - currentFunc.line, 1);
+  const nextFunc = functions[funcIndex + 1];
+  return {
+    startLine: func.line,
+    endLine: nextFunc ? nextFunc.line : Number.POSITIVE_INFINITY,
+  };
 }
 
-/** Count hit lines that fall within a function's estimated span. */
+/**
+ * Collect the coverable (instrumented) lines that fall within a function's
+ * span. Only lines the report actually tracks are coverable: non-executable
+ * lines such as type definitions, interface members, comments and braces never
+ * appear in the LCOV `DA` records, so they are excluded. This keeps a
+ * function's denominator equal to the lines that can genuinely be covered.
+ */
+function getFunctionCoverableLines(
+  func: FunctionCoverage,
+  fileCoverage: FileCoverage,
+): LineCoverage[] {
+  const { startLine, endLine } = getFunctionLineRange(func, fileCoverage);
+  return fileCoverage.lines.filter(
+    (line) => line.line >= startLine && line.line < endLine,
+  );
+}
+
+/**
+ * Count the coverable lines attributed to a function. This is the denominator
+ * for the tile's coverage ratio and drives its relative size.
+ */
+function getFunctionLineCount(
+  func: FunctionCoverage,
+  fileCoverage: FileCoverage,
+): number {
+  return getFunctionCoverableLines(func, fileCoverage).length;
+}
+
+/** Count the covered (hit) lines among a function's coverable lines. */
 function getFunctionCoveredLines(
   func: FunctionCoverage,
   fileCoverage: FileCoverage,
 ): number {
-  const startLine = func.line;
-  const endLine = startLine + getFunctionLineCount(func, fileCoverage);
-
-  return fileCoverage.lines.filter(
-    (line) => line.line >= startLine && line.line < endLine && line.hit > 0,
+  return getFunctionCoverableLines(func, fileCoverage).filter(
+    (line) => line.hit > 0,
   ).length;
 }


### PR DESCRIPTION
## Problem

The per-function treemap derived each function's denominator from the **physical line gap** to the next function's declaration (and a fixed 10-line estimate for the last function in a file). That span swept up lines that can never be covered — type aliases, interface members, JSDoc comments, blank lines and braces — none of which appear as LCOV `DA` records.

As a result, functions separated by such constructs were rendered as partially covered even when every coverable line was hit. For example, a TypeScript module with two small functions interleaved with type definitions showed `normalizeState` as 1/5 and `hasRecorderError` as 1/10, while the file's actual line coverage was 3/3 (100%).

## Fix

Count only the instrumented (`DA`) lines that fall within a function's `[start, nextStart)` span. The denominator now reflects genuinely coverable lines, so non-executable lines no longer drag a function's coverage down. Both `getFunctionLineCount` (tile size + denominator) and `getFunctionCoveredLines` (numerator) share a single span/filter helper, and the last function in a file is now unbounded instead of relying on a 10-line estimate.

Removed the now-dead `DEFAULT_FUNCTION_LINE_COUNT` and `MIN_FUNCTION_SIZE_ESTIMATE` constants.

## Testing

- Added a regression test mirroring a TS module whose functions are separated by type definitions; both functions now report 1/1 → fully covered.
- `npm run build` (tsc) and `npm run lint` clean; full suite (238 tests) passes.
- Rebuilt the committed `dist/` bundle so the fix takes effect when the action is pinned by SHA.