### PR TITLE
FS-26685: Shorten and dedupe coverage annotations for templated code

### DIFF
--- a/src/checksService.test.ts
+++ b/src/checksService.test.ts
@@ -902,6 +902,191 @@ describe("ChecksService", () => {
         ),
       ).toBe(true);
     });
+
+    // Templated C++ emits one function (and line) record per instantiation,
+    // all sharing a source line. The following cases pin down the behaviour
+    // for that shape: covering any instantiation counts as covered, and the
+    // resulting message stays short instead of dumping every signature.
+    const templatedAnalysis: FileChangeWithCoverage["analysis"] = {
+      totalLines: 10,
+      coveredLines: 8,
+      totalFunctions: 4,
+      coveredFunctions: 3,
+      totalBranches: 0,
+      coveredBranches: 0,
+      linesCoveragePercentage: 80,
+      functionsCoveragePercentage: 75,
+      branchesCoveragePercentage: 0,
+      overallCoveragePercentage: 80,
+    };
+
+    const wrapAnalysis = (file: FileChangeWithCoverage): CoverageAnalysis => ({
+      changeset: ChangesetUtils.createChangeset(
+        [file.path],
+        "base-sha",
+        "head-sha",
+        "main",
+      ),
+      changedFiles: [file],
+      summary: {
+        totalChangedFiles: 1,
+        filesWithCoverage: 1,
+        filesWithoutCoverage: 0,
+        overallCoverage: {
+          totalLines: 10,
+          coveredLines: 8,
+          totalFunctions: 4,
+          coveredFunctions: 3,
+          totalBranches: 0,
+          coveredBranches: 0,
+          linesCoveragePercentage: 80,
+          functionsCoveragePercentage: 75,
+          branchesCoveragePercentage: 0,
+          overallCoveragePercentage: 80,
+        },
+      },
+    });
+
+    it("treats a templated function as covered when any instantiation is hit", () => {
+      const file: FileChangeWithCoverage = {
+        path: "src/templated.cpp",
+        status: "modified",
+        coverage: {
+          path: "src/templated.cpp",
+          functions: [
+            { name: "void process<int>(int)", hit: 0, line: 5 },
+            { name: "void process<double>(double)", hit: 3, line: 5 },
+          ],
+          branches: [],
+          lines: [],
+          summary: {
+            functionsFound: 2,
+            functionsHit: 1,
+            linesFound: 0,
+            linesHit: 0,
+            branchesFound: 0,
+            branchesHit: 0,
+          },
+        },
+        analysis: templatedAnalysis,
+      };
+
+      const annotations = checksService
+        .generateAnnotations(wrapAnalysis(file))
+        .filter((a) => a.title === "Uncovered Function");
+
+      expect(annotations).toEqual([]);
+    });
+
+    it("emits one concise annotation for many uncovered template instantiations", () => {
+      const file: FileChangeWithCoverage = {
+        path: "src/templated.cpp",
+        status: "modified",
+        coverage: {
+          path: "src/templated.cpp",
+          functions: [
+            { name: "void process<int>(int)", hit: 0, line: 5 },
+            { name: "void process<double>(double)", hit: 0, line: 5 },
+            { name: "void process<char>(char)", hit: 0, line: 5 },
+          ],
+          branches: [],
+          lines: [],
+          summary: {
+            functionsFound: 3,
+            functionsHit: 0,
+            linesFound: 0,
+            linesHit: 0,
+            branchesFound: 0,
+            branchesHit: 0,
+          },
+        },
+        analysis: templatedAnalysis,
+      };
+
+      const annotations = checksService
+        .generateAnnotations(wrapAnalysis(file))
+        .filter((a) => a.title === "Uncovered Function");
+
+      expect(annotations).toHaveLength(1);
+      expect(annotations[0]).toMatchObject({
+        path: "src/templated.cpp",
+        start_line: 5,
+        end_line: 5,
+        annotation_level: "warning",
+        message:
+          "Function 'void process<int>(int)' (+2 template instantiations) is not covered by tests",
+      });
+    });
+
+    it("truncates an extremely long templated function name", () => {
+      const longName =
+        "void apply<std::vector<std::pair<std::basic_string<char>, " +
+        "std::map<int, std::vector<double>>>>>(SomeVeryLongParameterTypeName " +
+        "const&, AnotherVeryLongParameterType&&)";
+      const file: FileChangeWithCoverage = {
+        path: "src/templated.cpp",
+        status: "modified",
+        coverage: {
+          path: "src/templated.cpp",
+          functions: [{ name: longName, hit: 0, line: 9 }],
+          branches: [],
+          lines: [],
+          summary: {
+            functionsFound: 1,
+            functionsHit: 0,
+            linesFound: 0,
+            linesHit: 0,
+            branchesFound: 0,
+            branchesHit: 0,
+          },
+        },
+        analysis: templatedAnalysis,
+      };
+
+      const annotations = checksService
+        .generateAnnotations(wrapAnalysis(file))
+        .filter((a) => a.title === "Uncovered Function");
+
+      expect(annotations).toHaveLength(1);
+      const message = annotations[0]!.message;
+      expect(message.length).toBeLessThanOrEqual(120);
+      expect(message).toContain("…");
+      expect(message).toContain("void apply<");
+      expect(message).toContain("is not covered by tests");
+    });
+
+    it("treats a line as covered when any duplicate line record is hit", () => {
+      const file: FileChangeWithCoverage = {
+        path: "src/templated.cpp",
+        status: "modified",
+        coverage: {
+          path: "src/templated.cpp",
+          functions: [],
+          branches: [],
+          // One source line instrumented once per instantiation: one miss and
+          // one hit. The line is covered overall.
+          lines: [
+            { line: 12, hit: 0 },
+            { line: 12, hit: 4 },
+          ],
+          summary: {
+            functionsFound: 0,
+            functionsHit: 0,
+            linesFound: 2,
+            linesHit: 1,
+            branchesFound: 0,
+            branchesHit: 0,
+          },
+        },
+        analysis: templatedAnalysis,
+      };
+
+      const annotations = checksService
+        .generateAnnotations(wrapAnalysis(file))
+        .filter((a) => a.title === "Uncovered Lines");
+
+      expect(annotations).toEqual([]);
+    });
   });
 
   describe("generateCheckTitle", () => {

--- a/src/checksService.ts
+++ b/src/checksService.ts
@@ -3,6 +3,7 @@ import * as github from "@actions/github";
 import { createAppAuth } from "@octokit/auth-app";
 import { CoverageAnalysis, FileChangeWithCoverage } from "./coverageAnalyzer";
 import { GatingResult } from "./coverageGating";
+import { FunctionCoverage } from "./lcov";
 
 export interface CheckAnnotation {
   path: string;
@@ -25,6 +26,11 @@ export interface ChecksServiceConfig {
 export class ChecksService {
   private config: ChecksServiceConfig;
   private maxAnnotations = 50;
+
+  // Demangled C++ template signatures can run to hundreds of characters, which
+  // renders check annotations unreadable. Truncate names past this length so a
+  // single annotation never spans multiple screens.
+  private static readonly maxFunctionNameLength = 80;
 
   constructor(config: ChecksServiceConfig) {
     this.config = config;
@@ -107,14 +113,23 @@ export class ChecksService {
     if (!file.coverage) return [];
 
     const isInChangeset = this.changedLinePredicate(file);
-    const uncoveredLines = file.coverage.lines.filter(
-      (line) => line.hit === 0 && isInChangeset(line.line),
-    );
+
+    // Templated code is instrumented once per instantiation, so a source line
+    // can appear in several DA records with differing hit counts. Collapse them
+    // to the highest hit count: the line is covered if any instantiation hit
+    // it, avoiding spurious "uncovered" annotations on covered template code.
+    const maxHitByLine = new Map<number, number>();
+    for (const line of file.coverage.lines) {
+      const previous = maxHitByLine.get(line.line) ?? 0;
+      maxHitByLine.set(line.line, Math.max(previous, line.hit));
+    }
+
+    const uncoveredLineNumbers = [...maxHitByLine.entries()]
+      .filter(([lineNumber, hit]) => hit === 0 && isInChangeset(lineNumber))
+      .map(([lineNumber]) => lineNumber);
     const annotations: CheckAnnotation[] = [];
 
-    const lineGroups = this.groupConsecutiveLines(
-      uncoveredLines.map((l) => l.line),
-    );
+    const lineGroups = this.groupConsecutiveLines(uncoveredLineNumbers);
 
     for (const group of lineGroups) {
       const startLine = group[0];
@@ -143,23 +158,65 @@ export class ChecksService {
     if (!file.coverage) return [];
 
     const isInChangeset = this.changedLinePredicate(file);
-    const uncoveredFunctions = file.coverage.functions.filter(
-      (fn) => fn.hit === 0 && isInChangeset(fn.line),
-    );
-    const annotations: CheckAnnotation[] = [];
 
-    for (const func of uncoveredFunctions) {
+    // A templated function is emitted once per instantiation, each a distinct
+    // (very long) name sharing one line. Group by line so covering a single
+    // instantiation counts as covered and every uncovered line yields at most
+    // one annotation instead of one per instantiation.
+    const functionsByLine = new Map<number, FunctionCoverage[]>();
+    for (const func of file.coverage.functions) {
+      const group = functionsByLine.get(func.line);
+      if (group) {
+        group.push(func);
+      } else {
+        functionsByLine.set(func.line, [func]);
+      }
+    }
+
+    const annotations: CheckAnnotation[] = [];
+    for (const [line, instantiations] of functionsByLine) {
+      if (!isInChangeset(line)) continue;
+      if (instantiations.some((func) => func.hit > 0)) continue;
+
       annotations.push({
         path: file.path,
-        start_line: func.line,
-        end_line: func.line,
+        start_line: line,
+        end_line: line,
         annotation_level: "warning",
         title: "Uncovered Function",
-        message: `Function '${func.name}' is not covered by tests`,
+        message: this.formatUncoveredFunctionMessage(instantiations),
       });
     }
 
     return annotations;
+  }
+
+  // Builds a concise message for an uncovered function line. Templated code
+  // maps to several instantiations sharing the line; we surface one readable
+  // (truncated) name plus a count of the remaining instantiations rather than
+  // listing every multi-hundred-character signature.
+  private formatUncoveredFunctionMessage(
+    instantiations: FunctionCoverage[],
+  ): string {
+    const uniqueNames = [...new Set(instantiations.map((func) => func.name))];
+    const shortestName = uniqueNames.reduce((shortest, name) =>
+      name.length < shortest.length ? name : shortest,
+    );
+    const displayName = this.truncateFunctionName(shortestName);
+    const otherCount = uniqueNames.length - 1;
+
+    if (otherCount > 0) {
+      const suffix = otherCount === 1 ? "instantiation" : "instantiations";
+      return `Function '${displayName}' (+${otherCount} template ${suffix}) is not covered by tests`;
+    }
+
+    return `Function '${displayName}' is not covered by tests`;
+  }
+
+  private truncateFunctionName(name: string): string {
+    const maxLength = ChecksService.maxFunctionNameLength;
+    if (name.length <= maxLength) return name;
+    return `${name.slice(0, maxLength - 1)}\u2026`;
   }
 
   // Restricts uncovered-code annotations to changeset-touched lines. When


### PR DESCRIPTION
## Description

Heavily templated C++ makes the coverage check annotations unreadable. LCOV instruments a template once per instantiation, so a single source line yields many function records that:

- each carry a multi-hundred-character demangled signature (e.g. `void apply<std::vector<std::pair<...>>>(...)`), and
- share the same line, with only some instantiations actually hit by a test.

The previous behaviour emitted **one annotation per instantiation**, repeated the **full signature** in each message, and flagged a function as uncovered even when another instantiation of it *was* covered. 

This change groups function and line records by source line:

- **Coverage is per-line, not per-instantiation.** A line (or function) counts as covered when *any* instantiation is hit, so we no longer require every template instantiation to be exercised by a test.
- **One annotation per uncovered line.** Uncovered instantiations of the same function collapse into a single annotation.
- **Concise messages.** The surfaced signature is truncated at 80 chars with an ellipsis, and a `(+N template instantiations)` suffix reports how many other signatures share the line — instead of dumping every signature.

Line annotations get the same treatment: duplicate `DA` records for one line are collapsed to their highest hit count, so a line covered by one instantiation is no longer reported as uncovered.

## Testing

- `npm test` — full suite green (257 tests), including 4 new `ChecksService.generateAnnotations` cases covering: a mixed hit/miss instantiation set (no annotation), an all-uncovered instantiation set (single concise message with count), an extremely long single signature (truncated), and duplicate line records with one hit (no line annotation).
- `npx prettier --check` and `npx tsc --noEmit` pass on the changed files.
- `dist/index.js` rebuilt via `npm run package` (enforced by the `package-dist` pre-commit hook).