### PR TITLE
Fall back to default patterns when only one pattern input is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ The action supports file filtering using glob patterns to control which files ar
   - Use `source-code-pattern` to specify which files to **include in coverage** analysis.
   - Use `test-code-pattern` to specify which files to **exclude from coverage** analysis.
 
-The two inputs are independent: when only one of them is set, the built-in default patterns remain in effect for the other.
-For example, setting only `test-code-pattern` still analyzes all files matching the default source patterns (common code file extensions) minus your custom test patterns.
-
 #### Pattern Examples
 
 **Include only TypeScript files in src/ directory:**

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ The action supports file filtering using glob patterns to control which files ar
   - Use `source-code-pattern` to specify which files to **include in coverage** analysis.
   - Use `test-code-pattern` to specify which files to **exclude from coverage** analysis.
 
+The two inputs are independent: when only one of them is set, the built-in default patterns remain in effect for the other.
+For example, setting only `test-code-pattern` still analyzes all files matching the default source patterns (common code file extensions) minus your custom test patterns.
+
 #### Pattern Examples
 
 **Include only TypeScript files in src/ directory:**

--- a/dist/index.js
+++ b/dist/index.js
@@ -63380,14 +63380,16 @@ var ChangesetUtils = class _ChangesetUtils {
     };
   }
   static filterByPatterns(changeset, sourceCodePattern = _ChangesetUtils.DEFAULT_SOURCE_PATTERNS, testCodePattern = _ChangesetUtils.DEFAULT_TEST_PATTERNS) {
+    const sourcePatterns = sourceCodePattern.length > 0 ? sourceCodePattern : _ChangesetUtils.DEFAULT_SOURCE_PATTERNS;
+    const testPatterns = testCodePattern.length > 0 ? testCodePattern : _ChangesetUtils.DEFAULT_TEST_PATTERNS;
     const filteredFiles = changeset.files.filter((file) => {
       const matchesSource = _ChangesetUtils.matchesAnyPattern(
         file.path,
-        sourceCodePattern
+        sourcePatterns
       );
       const matchesTest = _ChangesetUtils.matchesAnyPattern(
         file.path,
-        testCodePattern
+        testPatterns
       );
       return matchesSource && !matchesTest;
     });

--- a/src/changeset.patterns.test.ts
+++ b/src/changeset.patterns.test.ts
@@ -118,16 +118,44 @@ describe("ChangesetUtils - Pattern Filtering", () => {
       expect(result.targetBranch).toBe("main");
     });
 
-    it("should handle empty patterns gracefully", () => {
-      // Test with empty arrays - this should match no files since an empty array means "match nothing"
+    it("should fall back to defaults when empty pattern lists are provided", () => {
+      // Unset inputs parse to empty arrays; both fall back to the defaults.
+      const result = ChangesetUtils.filterByPatterns(sampleChangeset, [], []);
+
+      expect(result.files.map((f) => f.path)).toEqual([
+        "src/main.ts",
+        "src/utils.js",
+        "src/components/Button.tsx",
+        "lib/helper.py",
+      ]);
+    });
+
+    it("should keep default source patterns when only test patterns are provided", () => {
+      // Regression test for #60: test-code-pattern alone must not drop all files.
       const result = ChangesetUtils.filterByPatterns(
         sampleChangeset,
-        [], // Empty source patterns = match nothing
-        [], // Empty test patterns = exclude nothing
+        ChangesetUtils.parsePatterns(undefined),
+        ChangesetUtils.parsePatterns("**/*.test.*"),
       );
 
-      // Empty source patterns should result in no matches
-      expect(result.files).toHaveLength(0);
+      expect(result.files.map((f) => f.path)).toEqual([
+        "src/main.ts",
+        "src/utils.js",
+        "src/components/Button.tsx",
+        "lib/helper.py",
+        "src/utils.spec.js", // custom test pattern replaces the defaults
+        "src/components/Button.mock.ts",
+      ]);
+    });
+
+    it("should keep default test patterns when only source patterns are provided", () => {
+      const result = ChangesetUtils.filterByPatterns(
+        sampleChangeset,
+        ChangesetUtils.parsePatterns("**/*.ts"),
+        ChangesetUtils.parsePatterns(undefined),
+      );
+
+      expect(result.files.map((f) => f.path)).toEqual(["src/main.ts"]);
     });
 
     it("should use default patterns when no arguments provided", () => {

--- a/src/changeset.ts
+++ b/src/changeset.ts
@@ -86,14 +86,26 @@ export class ChangesetUtils {
     sourceCodePattern: string[] = ChangesetUtils.DEFAULT_SOURCE_PATTERNS,
     testCodePattern: string[] = ChangesetUtils.DEFAULT_TEST_PATTERNS,
   ): Changeset {
+    // An unset input parses to an empty list; fall back to the defaults so
+    // providing only one of the two patterns keeps the other's documented
+    // default behaviour (e.g. test-code-pattern alone must not drop all files).
+    const sourcePatterns =
+      sourceCodePattern.length > 0
+        ? sourceCodePattern
+        : ChangesetUtils.DEFAULT_SOURCE_PATTERNS;
+    const testPatterns =
+      testCodePattern.length > 0
+        ? testCodePattern
+        : ChangesetUtils.DEFAULT_TEST_PATTERNS;
+
     const filteredFiles = changeset.files.filter((file) => {
       const matchesSource = ChangesetUtils.matchesAnyPattern(
         file.path,
-        sourceCodePattern,
+        sourcePatterns,
       );
       const matchesTest = ChangesetUtils.matchesAnyPattern(
         file.path,
-        testCodePattern,
+        testPatterns,
       );
 
       return matchesSource && !matchesTest;


### PR DESCRIPTION
## Summary

Fixes #60.

Setting `test-code-pattern` without `source-code-pattern` passed an empty source pattern list to `ChangesetUtils.filterByPatterns`, which matched nothing and silently dropped **all** files from the analysis.

`filterByPatterns` now treats an empty pattern list as "use the built-in defaults" for both parameters (option 1 from the issue), so the two inputs work independently as documented:

- Only `test-code-pattern` set → default source patterns stay in effect, custom test patterns exclude files.
- Only `source-code-pattern` set → default test patterns stay in effect (unchanged behaviour, now explicit).

## Changes

- `src/changeset.ts`: empty pattern lists fall back to `DEFAULT_SOURCE_PATTERNS` / `DEFAULT_TEST_PATTERNS`.
- `src/changeset.patterns.test.ts`: regression tests for standalone `test-code-pattern` and `source-code-pattern`.
- `README.md`: documents that the two inputs are independent.
- `dist/index.js`: repackaged bundle.

## Testing

`npm run lint && npm run test && npm run build && npm run package` — 259 tests pass.