### PR TITLE
Collapse annotations to a single file-level warning at 0% coverage

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -118138,7 +118138,7 @@ var ChecksService = class _ChecksService {
       const uncoveredLineAnnotations = this.generateUncoveredLineAnnotations(file);
       const uncoveredFunctionAnnotations = this.generateUncoveredFunctionAnnotations(file);
       const touchedUncoveredCode = uncoveredLineAnnotations.length > 0 || uncoveredFunctionAnnotations.length > 0;
-      if (touchedUncoveredCode && file.analysis.overallCoveragePercentage === 0) {
+      if (touchedUncoveredCode && this.hasNoCoveredCode(file)) {
         annotations.push({
           path: file.path,
           start_line: 1,
@@ -118164,6 +118164,10 @@ var ChecksService = class _ChecksService {
       }
     }
     return this.prioritizeAndLimitAnnotations(annotations);
+  }
+  hasNoCoveredCode(file) {
+    const { coveredLines, coveredFunctions, coveredBranches } = file.analysis;
+    return coveredLines === 0 && coveredFunctions === 0 && coveredBranches === 0;
   }
   generateUncoveredLineAnnotations(file) {
     if (!file.coverage) return [];

--- a/dist/index.js
+++ b/dist/index.js
@@ -118135,22 +118135,24 @@ var ChecksService = class _ChecksService {
         });
         continue;
       }
-      const uncoveredLineAnnotations = this.generateUncoveredLineAnnotations(file);
-      const uncoveredFunctionAnnotations = this.generateUncoveredFunctionAnnotations(file);
-      const touchedUncoveredCode = uncoveredLineAnnotations.length > 0 || uncoveredFunctionAnnotations.length > 0;
-      if (touchedUncoveredCode && this.hasNoCoveredCode(file)) {
-        annotations.push({
-          path: file.path,
-          start_line: 1,
-          end_line: 1,
-          annotation_level: "warning",
-          title: "No Coverage",
-          message: "File coverage is 0%. Nothing in this file is covered by tests."
-        });
+      if (this.hasNoCoveredCode(file)) {
+        if (this.changesetTouchesCoverableCode(file)) {
+          annotations.push({
+            path: file.path,
+            start_line: 1,
+            end_line: 1,
+            annotation_level: "warning",
+            title: "No Coverage",
+            message: "File coverage is 0%. Nothing in this file is covered by tests."
+          });
+        }
         continue;
       }
+      const uncoveredLineAnnotations = this.generateUncoveredLineAnnotations(file);
       annotations.push(...uncoveredLineAnnotations);
+      const uncoveredFunctionAnnotations = this.generateUncoveredFunctionAnnotations(file);
       annotations.push(...uncoveredFunctionAnnotations);
+      const touchedUncoveredCode = uncoveredLineAnnotations.length > 0 || uncoveredFunctionAnnotations.length > 0;
       if (touchedUncoveredCode && file.analysis.overallCoveragePercentage < 80) {
         annotations.push({
           path: file.path,
@@ -118168,6 +118170,14 @@ var ChecksService = class _ChecksService {
   hasNoCoveredCode(file) {
     const { coveredLines, coveredFunctions, coveredBranches } = file.analysis;
     return coveredLines === 0 && coveredFunctions === 0 && coveredBranches === 0;
+  }
+  // Cheap equivalent of "would any uncovered annotation be generated" for
+  // files without covered code: everything is uncovered there, so it suffices
+  // to check whether the changeset touched any coverable line at all.
+  changesetTouchesCoverableCode(file) {
+    if (!file.coverage) return false;
+    const isInChangeset = this.changedLinePredicate(file);
+    return file.coverage.lines.some((line) => isInChangeset(line.line)) || file.coverage.functions.some((func) => isInChangeset(func.line));
   }
   generateUncoveredLineAnnotations(file) {
     if (!file.coverage) return [];

--- a/dist/index.js
+++ b/dist/index.js
@@ -118136,10 +118136,21 @@ var ChecksService = class _ChecksService {
         continue;
       }
       const uncoveredLineAnnotations = this.generateUncoveredLineAnnotations(file);
-      annotations.push(...uncoveredLineAnnotations);
       const uncoveredFunctionAnnotations = this.generateUncoveredFunctionAnnotations(file);
-      annotations.push(...uncoveredFunctionAnnotations);
       const touchedUncoveredCode = uncoveredLineAnnotations.length > 0 || uncoveredFunctionAnnotations.length > 0;
+      if (touchedUncoveredCode && file.analysis.overallCoveragePercentage === 0) {
+        annotations.push({
+          path: file.path,
+          start_line: 1,
+          end_line: 1,
+          annotation_level: "warning",
+          title: "No Coverage",
+          message: "File coverage is 0%. Nothing in this file is covered by tests."
+        });
+        continue;
+      }
+      annotations.push(...uncoveredLineAnnotations);
+      annotations.push(...uncoveredFunctionAnnotations);
       if (touchedUncoveredCode && file.analysis.overallCoveragePercentage < 80) {
         annotations.push({
           path: file.path,

--- a/src/checksService.test.ts
+++ b/src/checksService.test.ts
@@ -597,6 +597,150 @@ describe("ChecksService", () => {
       });
     });
 
+    it("should emit only a single file-level annotation when file coverage is 0%", () => {
+      // Regression test for #63: per-line and per-function annotations add no
+      // information when nothing in the file is covered.
+      const fileWithZeroCoverage: FileChangeWithCoverage = {
+        path: "src/test.ts",
+        status: "added",
+        coverage: {
+          path: "src/test.ts",
+          functions: [{ name: "testFunction", hit: 0, line: 5 }],
+          branches: [],
+          lines: [
+            { line: 3, hit: 0 },
+            { line: 5, hit: 0 },
+            { line: 7, hit: 0 },
+          ],
+          summary: {
+            functionsFound: 1,
+            functionsHit: 0,
+            linesFound: 3,
+            linesHit: 0,
+            branchesFound: 0,
+            branchesHit: 0,
+          },
+        },
+        analysis: {
+          totalLines: 3,
+          coveredLines: 0,
+          totalFunctions: 1,
+          coveredFunctions: 0,
+          totalBranches: 0,
+          coveredBranches: 0,
+          linesCoveragePercentage: 0,
+          functionsCoveragePercentage: 0,
+          branchesCoveragePercentage: 0,
+          overallCoveragePercentage: 0,
+        },
+      };
+
+      const analysis: CoverageAnalysis = {
+        changeset: ChangesetUtils.createChangeset(
+          ["src/test.ts"],
+          "base-sha",
+          "head-sha",
+          "main",
+        ),
+        changedFiles: [fileWithZeroCoverage],
+        summary: {
+          totalChangedFiles: 1,
+          filesWithCoverage: 1,
+          filesWithoutCoverage: 0,
+          overallCoverage: {
+            totalLines: 3,
+            coveredLines: 0,
+            totalFunctions: 1,
+            coveredFunctions: 0,
+            totalBranches: 0,
+            coveredBranches: 0,
+            linesCoveragePercentage: 0,
+            functionsCoveragePercentage: 0,
+            branchesCoveragePercentage: 0,
+            overallCoveragePercentage: 0,
+          },
+        },
+      };
+
+      const annotations = checksService.generateAnnotations(analysis);
+
+      expect(annotations).toHaveLength(1);
+      expect(annotations[0]).toEqual({
+        path: "src/test.ts",
+        start_line: 1,
+        end_line: 1,
+        annotation_level: "warning",
+        title: "No Coverage",
+        message:
+          "File coverage is 0%. Nothing in this file is covered by tests.",
+      });
+    });
+
+    it("should emit no annotations for a 0% coverage file the changeset did not touch", () => {
+      const fileWithZeroCoverage: FileChangeWithCoverage = {
+        path: "src/test.ts",
+        status: "modified",
+        changedLines: [],
+        coverage: {
+          path: "src/test.ts",
+          functions: [{ name: "testFunction", hit: 0, line: 5 }],
+          branches: [],
+          lines: [{ line: 3, hit: 0 }],
+          summary: {
+            functionsFound: 1,
+            functionsHit: 0,
+            linesFound: 1,
+            linesHit: 0,
+            branchesFound: 0,
+            branchesHit: 0,
+          },
+        },
+        analysis: {
+          totalLines: 1,
+          coveredLines: 0,
+          totalFunctions: 1,
+          coveredFunctions: 0,
+          totalBranches: 0,
+          coveredBranches: 0,
+          linesCoveragePercentage: 0,
+          functionsCoveragePercentage: 0,
+          branchesCoveragePercentage: 0,
+          overallCoveragePercentage: 0,
+        },
+      };
+
+      const analysis: CoverageAnalysis = {
+        changeset: ChangesetUtils.createChangeset(
+          ["src/test.ts"],
+          "base-sha",
+          "head-sha",
+          "main",
+        ),
+        changedFiles: [fileWithZeroCoverage],
+        summary: {
+          totalChangedFiles: 1,
+          filesWithCoverage: 1,
+          filesWithoutCoverage: 0,
+          overallCoverage: {
+            totalLines: 1,
+            coveredLines: 0,
+            totalFunctions: 1,
+            coveredFunctions: 0,
+            totalBranches: 0,
+            coveredBranches: 0,
+            linesCoveragePercentage: 0,
+            functionsCoveragePercentage: 0,
+            branchesCoveragePercentage: 0,
+            overallCoveragePercentage: 0,
+          },
+        },
+      };
+
+      const annotations = checksService.generateAnnotations(analysis);
+
+      expect(annotations).toHaveLength(0);
+    });
+
     it("should return empty array when no coverage issues", () => {
       const fileWithFullCoverage: FileChangeWithCoverage = {
         path: "src/test.ts",

--- a/src/checksService.test.ts
+++ b/src/checksService.test.ts
@@ -741,6 +741,86 @@ describe("ChecksService", () => {
       expect(annotations).toHaveLength(0);
     });
 
+    it("should keep inline annotations when tiny coverage rounds to 0%", () => {
+      // overallCoveragePercentage is rounded to 2 decimals, so a file with
+      // e.g. 0.004% coverage reports 0. Covered counts distinguish it from
+      // truly uncovered files.
+      const fileWithTinyCoverage: FileChangeWithCoverage = {
+        path: "src/test.ts",
+        status: "modified",
+        coverage: {
+          path: "src/test.ts",
+          functions: [],
+          branches: [],
+          lines: [
+            { line: 1, hit: 1 },
+            { line: 3, hit: 0 },
+          ],
+          summary: {
+            functionsFound: 0,
+            functionsHit: 0,
+            linesFound: 25000,
+            linesHit: 1,
+            branchesFound: 0,
+            branchesHit: 0,
+          },
+        },
+        analysis: {
+          totalLines: 25000,
+          coveredLines: 1,
+          totalFunctions: 0,
+          coveredFunctions: 0,
+          totalBranches: 0,
+          coveredBranches: 0,
+          linesCoveragePercentage: 0,
+          functionsCoveragePercentage: 0,
+          branchesCoveragePercentage: 0,
+          overallCoveragePercentage: 0,
+        },
+      };
+
+      const analysis: CoverageAnalysis = {
+        changeset: ChangesetUtils.createChangeset(
+          ["src/test.ts"],
+          "base-sha",
+          "head-sha",
+          "main",
+        ),
+        changedFiles: [fileWithTinyCoverage],
+        summary: {
+          totalChangedFiles: 1,
+          filesWithCoverage: 1,
+          filesWithoutCoverage: 0,
+          overallCoverage: {
+            totalLines: 25000,
+            coveredLines: 1,
+            totalFunctions: 0,
+            coveredFunctions: 0,
+            totalBranches: 0,
+            coveredBranches: 0,
+            linesCoveragePercentage: 0,
+            functionsCoveragePercentage: 0,
+            branchesCoveragePercentage: 0,
+            overallCoveragePercentage: 0,
+          },
+        },
+      };
+
+      const annotations = checksService.generateAnnotations(analysis);
+
+      expect(
+        annotations.find((a) => a.title === "No Coverage"),
+      ).toBeUndefined();
+      expect(annotations.find((a) => a.title === "Uncovered Lines")).toEqual({
+        path: "src/test.ts",
+        start_line: 3,
+        end_line: 3,
+        annotation_level: "warning",
+        title: "Uncovered Lines",
+        message: "Line 3 is not covered by tests",
+      });
+    });
+
     it("should return empty array when no coverage issues", () => {
       const fileWithFullCoverage: FileChangeWithCoverage = {
         path: "src/test.ts",

--- a/src/checksService.ts
+++ b/src/checksService.ts
@@ -74,37 +74,40 @@ export class ChecksService {
         continue;
       }
 
+      // At 0% file coverage every line is uncovered, so per-line and
+      // per-function annotations add no information. Short-circuit before
+      // building them: a single file-level warning says it all, gated on the
+      // changeset actually touching the file's uncovered code. Covered counts
+      // are compared instead of the rounded percentage so files with tiny
+      // non-zero coverage keep their inline annotations.
+      if (this.hasNoCoveredCode(file)) {
+        if (this.changesetTouchesCoverableCode(file)) {
+          annotations.push({
+            path: file.path,
+            start_line: 1,
+            end_line: 1,
+            annotation_level: "warning",
+            title: "No Coverage",
+            message:
+              "File coverage is 0%. Nothing in this file is covered by tests.",
+          });
+        }
+        continue;
+      }
+
       const uncoveredLineAnnotations =
         this.generateUncoveredLineAnnotations(file);
+      annotations.push(...uncoveredLineAnnotations);
+
       const uncoveredFunctionAnnotations =
         this.generateUncoveredFunctionAnnotations(file);
+      annotations.push(...uncoveredFunctionAnnotations);
 
       // Only complement changeset-touched uncovered code: skip the notice when
       // no uncovered lines or functions were introduced.
       const touchedUncoveredCode =
         uncoveredLineAnnotations.length > 0 ||
         uncoveredFunctionAnnotations.length > 0;
-
-      // At 0% file coverage every line is uncovered, so per-line and
-      // per-function annotations add no information. A single file-level
-      // warning says it all. Check covered counts rather than the rounded
-      // percentage so files with tiny non-zero coverage keep their inline
-      // annotations.
-      if (touchedUncoveredCode && this.hasNoCoveredCode(file)) {
-        annotations.push({
-          path: file.path,
-          start_line: 1,
-          end_line: 1,
-          annotation_level: "warning",
-          title: "No Coverage",
-          message:
-            "File coverage is 0%. Nothing in this file is covered by tests.",
-        });
-        continue;
-      }
-
-      annotations.push(...uncoveredLineAnnotations);
-      annotations.push(...uncoveredFunctionAnnotations);
 
       if (
         touchedUncoveredCode &&
@@ -129,6 +132,19 @@ export class ChecksService {
     const { coveredLines, coveredFunctions, coveredBranches } = file.analysis;
     return (
       coveredLines === 0 && coveredFunctions === 0 && coveredBranches === 0
+    );
+  }
+
+  // Cheap equivalent of "would any uncovered annotation be generated" for
+  // files without covered code: everything is uncovered there, so it suffices
+  // to check whether the changeset touched any coverable line at all.
+  private changesetTouchesCoverableCode(file: FileChangeWithCoverage): boolean {
+    if (!file.coverage) return false;
+
+    const isInChangeset = this.changedLinePredicate(file);
+    return (
+      file.coverage.lines.some((line) => isInChangeset(line.line)) ||
+      file.coverage.functions.some((func) => isInChangeset(func.line))
     );
   }
 

--- a/src/checksService.ts
+++ b/src/checksService.ts
@@ -76,17 +76,36 @@ export class ChecksService {
 
       const uncoveredLineAnnotations =
         this.generateUncoveredLineAnnotations(file);
-      annotations.push(...uncoveredLineAnnotations);
-
       const uncoveredFunctionAnnotations =
         this.generateUncoveredFunctionAnnotations(file);
-      annotations.push(...uncoveredFunctionAnnotations);
 
       // Only complement changeset-touched uncovered code: skip the notice when
       // no uncovered lines or functions were introduced.
       const touchedUncoveredCode =
         uncoveredLineAnnotations.length > 0 ||
         uncoveredFunctionAnnotations.length > 0;
+
+      // At 0% file coverage every line is uncovered, so per-line and
+      // per-function annotations add no information. A single file-level
+      // warning says it all.
+      if (
+        touchedUncoveredCode &&
+        file.analysis.overallCoveragePercentage === 0
+      ) {
+        annotations.push({
+          path: file.path,
+          start_line: 1,
+          end_line: 1,
+          annotation_level: "warning",
+          title: "No Coverage",
+          message:
+            "File coverage is 0%. Nothing in this file is covered by tests.",
+        });
+        continue;
+      }
+
+      annotations.push(...uncoveredLineAnnotations);
+      annotations.push(...uncoveredFunctionAnnotations);
 
       if (
         touchedUncoveredCode &&

--- a/src/checksService.ts
+++ b/src/checksService.ts
@@ -87,11 +87,10 @@ export class ChecksService {
 
       // At 0% file coverage every line is uncovered, so per-line and
       // per-function annotations add no information. A single file-level
-      // warning says it all.
-      if (
-        touchedUncoveredCode &&
-        file.analysis.overallCoveragePercentage === 0
-      ) {
+      // warning says it all. Check covered counts rather than the rounded
+      // percentage so files with tiny non-zero coverage keep their inline
+      // annotations.
+      if (touchedUncoveredCode && this.hasNoCoveredCode(file)) {
         annotations.push({
           path: file.path,
           start_line: 1,
@@ -124,6 +123,13 @@ export class ChecksService {
     }
 
     return this.prioritizeAndLimitAnnotations(annotations);
+  }
+
+  private hasNoCoveredCode(file: FileChangeWithCoverage): boolean {
+    const { coveredLines, coveredFunctions, coveredBranches } = file.analysis;
+    return (
+      coveredLines === 0 && coveredFunctions === 0 && coveredBranches === 0
+    );
   }
 
   private generateUncoveredLineAnnotations(


### PR DESCRIPTION
## Summary

Fixes #63.

When a file has 0% coverage, every line and function is uncovered, so the inline per-line and per-function annotations provide no additional information beyond the file-level warning.

`generateAnnotations` now emits a single file-level **No Coverage** warning for such files instead of flooding the diff with redundant "Uncovered Lines" / "Uncovered Function" annotations. The existing changeset-touched gate is preserved: files at 0% whose uncovered code was not touched by the PR still produce no annotations. This also frees up slots within the 50-annotation Checks API limit for files where line-level detail is actually useful.

## Changes

- `src/checksService.ts`: short-circuit to one file-level warning when file coverage is 0%.
- `src/checksService.test.ts`: tests for the collapsed annotation and for untouched 0% files.
- `dist/index.js`: repackaged bundle.

## Testing

`npm run lint && npm run test && npm run build && npm run package` — 259 tests pass.