### PR TITLE
Bump npm dependencies, GitHub Actions, and pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -45,7 +45,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -76,10 +76,10 @@ jobs:
       pull-requests: write
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Review dependencies
-      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
       with:
         comment-summary-in-pr: on-failure
 
@@ -95,7 +95,7 @@ jobs:
       run: echo "base-depth=$(expr "${PR_COMMITS:-0}" + 1)" | tee -a $GITHUB_OUTPUT
 
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
 
@@ -137,7 +137,7 @@ jobs:
         npm run package
 
     - name: Upload coverage reports
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage-report
         path: coverage/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,15 +29,15 @@ jobs:
         language: [javascript-typescript]
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -10,6 +10,8 @@ no-emphasis-as-heading: false
 code-block-style: false
 no-alt-text: false
 no-inline-html: false
+# Tables in this repo don't align pipes with the header row.
+table-column-style: false
 ul-indent:
   start_indent: 2
   start_indented: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ exclude: |-
   )$
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace
@@ -20,17 +20,17 @@ repos:
   - id: prettier
 
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v10.5.0
+  rev: v10.6.0
   hooks:
   - id: eslint
 
 - repo: https://github.com/lalten/check-gha-pinning
-  rev: v1.3.0
+  rev: v1.3.1
   hooks:
   - id: check-gha-pinning
 
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.45.0
+  rev: v0.49.0
   hooks:
   - id: markdownlint
     args: [--fix]
@@ -40,24 +40,24 @@ repos:
       )
 
 - repo: https://github.com/renovatebot/pre-commit-hooks
-  rev: 38.118.0
+  rev: 43.256.0
   hooks:
   - id: renovate-config-validator
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.2
   hooks:
   - id: codespell
     exclude: (?x)^( package-lock.json )
 
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.37.1
+  rev: v1.38.0
   hooks:
   - id: yamllint
     args: ["--strict", "-c=.yamllint.yaml"]
 
 - repo: https://github.com/google/yamlfmt
-  rev: v0.13.0
+  rev: v0.21.0
   hooks:
   - id: yamlfmt
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5437,7 +5437,7 @@ var require_body = __commonJS({
         const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, "0")}`;
         const prefix2 = `--${boundary}\r
 Content-Disposition: form-data`;
-        const escape4 = (str) => str.replace(/\n/g, "%0A").replace(/\r/g, "%0D").replace(/"/g, "%22");
+        const escape5 = (str) => str.replace(/\n/g, "%0A").replace(/\r/g, "%0D").replace(/"/g, "%22");
         const normalizeLinefeeds = (value) => value.replace(/\r?\n|\r/g, "\r\n");
         const blobParts = [];
         const rn = new Uint8Array([13, 10]);
@@ -5445,14 +5445,14 @@ Content-Disposition: form-data`;
         let hasUnknownSizeValue = false;
         for (const [name, value] of object) {
           if (typeof value === "string") {
-            const chunk2 = textEncoder.encode(prefix2 + `; name="${escape4(normalizeLinefeeds(name))}"\r
+            const chunk2 = textEncoder.encode(prefix2 + `; name="${escape5(normalizeLinefeeds(name))}"\r
 \r
 ${normalizeLinefeeds(value)}\r
 `);
             blobParts.push(chunk2);
             length += chunk2.byteLength;
           } else {
-            const chunk2 = textEncoder.encode(`${prefix2}; name="${escape4(normalizeLinefeeds(name))}"` + (value.name ? `; filename="${escape4(value.name)}"` : "") + `\r
+            const chunk2 = textEncoder.encode(`${prefix2}; name="${escape5(normalizeLinefeeds(name))}"` + (value.name ? `; filename="${escape5(value.name)}"` : "") + `\r
 Content-Type: ${value.type || "application/octet-stream"}\r
 \r
 `);
@@ -13442,7 +13442,7 @@ var require_fetch = __commonJS({
     function handleFetchDone(response) {
       finalizeAndReportTiming(response, "fetch");
     }
-    function fetch4(input, init2 = void 0) {
+    function fetch5(input, init2 = void 0) {
       webidl.argumentLengthCheck(arguments, 1, "globalThis.fetch");
       let p = createDeferredPromise();
       let requestObject;
@@ -14399,7 +14399,7 @@ var require_fetch = __commonJS({
       }
     }
     module.exports = {
-      fetch: fetch4,
+      fetch: fetch5,
       Fetch,
       fetching,
       finalizeAndReportTiming
@@ -16256,17 +16256,17 @@ var require_cookies = __commonJS({
       }
       return out;
     }
-    function deleteCookie(headers, name, attributes2) {
+    function deleteCookie(headers, name, attributes) {
       webidl.brandCheck(headers, Headers2, { strict: false });
       const prefix2 = "deleteCookie";
       webidl.argumentLengthCheck(arguments, 2, prefix2);
       name = webidl.converters.DOMString(name, prefix2, "name");
-      attributes2 = webidl.converters.DeleteCookieAttributes(attributes2);
+      attributes = webidl.converters.DeleteCookieAttributes(attributes);
       setCookie(headers, {
         name,
         value: "",
         expires: /* @__PURE__ */ new Date(0),
-        ...attributes2
+        ...attributes
       });
     }
     function getSetCookies(headers) {
@@ -18710,7 +18710,7 @@ var require_undici = __commonJS({
     module.exports.setGlobalDispatcher = setGlobalDispatcher;
     module.exports.getGlobalDispatcher = getGlobalDispatcher;
     var fetchImpl = require_fetch().fetch;
-    module.exports.fetch = async function fetch4(init2, options = void 0) {
+    module.exports.fetch = async function fetch5(init2, options = void 0) {
       try {
         return await fetchImpl(init2, options);
       } catch (err) {
@@ -19537,7 +19537,7 @@ var require_dist = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.format = format;
-    exports2.parse = parse9;
+    exports2.parse = parse8;
     var TEXT_REGEXP = /^[\u0009\u0020-\u007e\u0080-\u00ff]*$/;
     var TOKEN_REGEXP = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
     var QUOTE_REGEXP = /[\\"]/g;
@@ -19564,7 +19564,7 @@ var require_dist = __commonJS({
       }
       return result;
     }
-    function parse9(header, options) {
+    function parse8(header, options) {
       const len = header.length;
       let index = skipOWS(header, 0, len);
       const valueStart = index;
@@ -19909,9 +19909,9 @@ var require_utils2 = __commonJS({
       return output;
     };
     exports2.wrapOutput = (input, state3 = {}, options = {}) => {
-      const prepend2 = options.contains ? "" : "^";
-      const append3 = options.contains ? "" : "$";
-      let output = `${prepend2}(?:${input})${append3}`;
+      const prepend3 = options.contains ? "" : "^";
+      const append4 = options.contains ? "" : "$";
+      let output = `${prepend3}(?:${input})${append4}`;
       if (state3.negated === true) {
         output = `(?:^(?!${output}).*$)`;
       }
@@ -20436,7 +20436,11 @@ var require_parse2 = __commonJS({
         }
       }
     };
-    var getStarExtglobSequenceOutput = (pattern) => {
+    var buildCharClassStar = (chars) => {
+      const source = chars.length === 1 ? utils.escapeRegex(chars[0]) : `[${chars.map((ch) => utils.escapeRegex(ch)).join("")}]`;
+      return `${source}*`;
+    };
+    var getStarExtglobSequenceChars = (pattern) => {
       let index = 0;
       const chars = [];
       while (index < pattern.length) {
@@ -20458,8 +20462,7 @@ var require_parse2 = __commonJS({
       if (chars.length < 1) {
         return;
       }
-      const source = chars.length === 1 ? utils.escapeRegex(chars[0]) : `[${chars.map((ch) => utils.escapeRegex(ch)).join("")}]`;
-      return `${source}*`;
+      return chars;
     };
     var repeatedExtglobRecursion = (pattern) => {
       let depth = 0;
@@ -20483,18 +20486,32 @@ var require_parse2 = __commonJS({
           return { risky: true };
         }
       }
+      const safeChars = [];
+      let sawStarSequence = false;
+      let combinable = true;
       for (const branch of branches) {
-        const safeOutput = getStarExtglobSequenceOutput(branch);
-        if (safeOutput) {
-          return { risky: true, safeOutput };
+        const chars = getStarExtglobSequenceChars(branch);
+        if (chars) {
+          sawStarSequence = true;
+          safeChars.push(...chars);
+          continue;
         }
+        const literal = normalizeSimpleBranch(branch);
+        if (literal && literal.length === 1) {
+          safeChars.push(literal);
+          continue;
+        }
+        combinable = false;
         if (repeatedExtglobRecursion(branch) > max2) {
           return { risky: true };
         }
       }
+      if (sawStarSequence) {
+        return combinable ? { risky: true, safeOutput: buildCharClassStar([...new Set(safeChars)]) } : { risky: true };
+      }
       return { risky: false };
     };
-    var parse9 = (input, options) => {
+    var parse8 = (input, options) => {
       if (typeof input !== "string") {
         throw new TypeError("Expected a string");
       }
@@ -20568,7 +20585,7 @@ var require_parse2 = __commonJS({
         state3.consumed += value2;
         state3.index += num;
       };
-      const append3 = (token) => {
+      const append4 = (token) => {
         state3.output += token.output != null ? token.output : token.value;
         consume(token.value);
       };
@@ -20609,7 +20626,7 @@ var require_parse2 = __commonJS({
         if (extglobs.length && tok.type !== "paren") {
           extglobs[extglobs.length - 1].inner += tok.value;
         }
-        if (tok.value || tok.output) append3(tok);
+        if (tok.value || tok.output) append4(tok);
         if (prev && prev.type === "text" && tok.type === "text") {
           prev.output = (prev.output || prev.value) + tok.value;
           prev.value += tok.value;
@@ -20664,7 +20681,7 @@ var require_parse2 = __commonJS({
             output = token.close = `)$))${extglobStar}`;
           }
           if (token.inner.includes("*") && (rest = remaining()) && /^\.[^\\/.]+$/.test(rest)) {
-            const expression = parse9(rest, { ...options, fastpaths: false }).output;
+            const expression = parse8(rest, { ...options, fastpaths: false }).output;
             output = token.close = `)${expression})${extglobStar})`;
           }
           if (token.prev.type === "bos") {
@@ -20786,13 +20803,13 @@ var require_parse2 = __commonJS({
             value = "^";
           }
           prev.value += value;
-          append3({ value });
+          append4({ value });
           continue;
         }
         if (state3.quotes === 1 && value !== '"') {
           value = utils.escapeRegex(value);
           prev.value += value;
-          append3({ value });
+          append4({ value });
           continue;
         }
         if (value === '"') {
@@ -20850,7 +20867,7 @@ var require_parse2 = __commonJS({
             value = `/${value}`;
           }
           prev.value += value;
-          append3({ value });
+          append4({ value });
           if (opts.literalBrackets === false || utils.hasRegexChars(prevValue)) {
             continue;
           }
@@ -21186,7 +21203,7 @@ var require_parse2 = __commonJS({
       }
       return state3;
     };
-    parse9.fastpaths = (input, options) => {
+    parse8.fastpaths = (input, options) => {
       const opts = { ...options };
       const max2 = typeof opts.maxLength === "number" ? Math.min(MAX_LENGTH, opts.maxLength) : MAX_LENGTH;
       const len = input.length;
@@ -21251,7 +21268,7 @@ var require_parse2 = __commonJS({
       }
       return source;
     };
-    module.exports = parse9;
+    module.exports = parse8;
   }
 });
 
@@ -21260,7 +21277,7 @@ var require_picomatch = __commonJS({
   "node_modules/picomatch/lib/picomatch.js"(exports2, module) {
     "use strict";
     var scan = require_scan();
-    var parse9 = require_parse2();
+    var parse8 = require_parse2();
     var utils = require_utils2();
     var constants3 = require_constants6();
     var isObject2 = (val) => val && typeof val === "object" && !Array.isArray(val);
@@ -21341,14 +21358,14 @@ var require_picomatch = __commonJS({
       }
       return { isMatch: Boolean(match), match, output };
     };
-    picomatch2.matchBase = (input, glob, options) => {
+    picomatch2.matchBase = (input, glob, options, posix = options && options.windows) => {
       const regex = glob instanceof RegExp ? glob : picomatch2.makeRe(glob, options);
-      return regex.test(utils.basename(input));
+      return regex.test(utils.basename(input, { windows: posix }));
     };
     picomatch2.isMatch = (str, patterns, options) => picomatch2(patterns, options)(str);
     picomatch2.parse = (pattern, options) => {
       if (Array.isArray(pattern)) return pattern.map((p) => picomatch2.parse(p, options));
-      return parse9(pattern, { ...options, fastpaths: false });
+      return parse8(pattern, { ...options, fastpaths: false });
     };
     picomatch2.scan = (input, options) => scan(input, options);
     picomatch2.compileRe = (state3, options, returnOutput = false, returnState = false) => {
@@ -21356,9 +21373,9 @@ var require_picomatch = __commonJS({
         return state3.output;
       }
       const opts = options || {};
-      const prepend2 = opts.contains ? "" : "^";
-      const append3 = opts.contains ? "" : "$";
-      let source = `${prepend2}(?:${state3.output})${append3}`;
+      const prepend3 = opts.contains ? "" : "^";
+      const append4 = opts.contains ? "" : "$";
+      let source = `${prepend3}(?:${state3.output})${append4}`;
       if (state3 && state3.negated === true) {
         source = `^(?!${source}).*$`;
       }
@@ -21374,10 +21391,10 @@ var require_picomatch = __commonJS({
       }
       let parsed = { negated: false, fastpaths: true };
       if (options.fastpaths !== false && (input[0] === "." || input[0] === "*")) {
-        parsed.output = parse9.fastpaths(input, options);
+        parsed.output = parse8.fastpaths(input, options);
       }
       if (!parsed.output) {
-        parsed = parse9(input, options);
+        parsed = parse8(input, options);
       }
       return picomatch2.compileRe(parsed, options, returnOutput, returnState);
     };
@@ -21409,576 +21426,6 @@ var require_picomatch2 = __commonJS({
     }
     Object.assign(picomatch2, pico);
     module.exports = picomatch2;
-  }
-});
-
-// node_modules/boolbase/index.js
-var require_boolbase = __commonJS({
-  "node_modules/boolbase/index.js"(exports2, module) {
-    module.exports = {
-      trueFunc: function trueFunc() {
-        return true;
-      },
-      falseFunc: function falseFunc() {
-        return false;
-      }
-    };
-  }
-});
-
-// node_modules/css-what/lib/commonjs/types.js
-var require_types = __commonJS({
-  "node_modules/css-what/lib/commonjs/types.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.AttributeAction = exports2.IgnoreCaseMode = exports2.SelectorType = void 0;
-    var SelectorType4;
-    (function(SelectorType5) {
-      SelectorType5["Attribute"] = "attribute";
-      SelectorType5["Pseudo"] = "pseudo";
-      SelectorType5["PseudoElement"] = "pseudo-element";
-      SelectorType5["Tag"] = "tag";
-      SelectorType5["Universal"] = "universal";
-      SelectorType5["Adjacent"] = "adjacent";
-      SelectorType5["Child"] = "child";
-      SelectorType5["Descendant"] = "descendant";
-      SelectorType5["Parent"] = "parent";
-      SelectorType5["Sibling"] = "sibling";
-      SelectorType5["ColumnCombinator"] = "column-combinator";
-    })(SelectorType4 = exports2.SelectorType || (exports2.SelectorType = {}));
-    exports2.IgnoreCaseMode = {
-      Unknown: null,
-      QuirksMode: "quirks",
-      IgnoreCase: true,
-      CaseSensitive: false
-    };
-    var AttributeAction2;
-    (function(AttributeAction3) {
-      AttributeAction3["Any"] = "any";
-      AttributeAction3["Element"] = "element";
-      AttributeAction3["End"] = "end";
-      AttributeAction3["Equals"] = "equals";
-      AttributeAction3["Exists"] = "exists";
-      AttributeAction3["Hyphen"] = "hyphen";
-      AttributeAction3["Not"] = "not";
-      AttributeAction3["Start"] = "start";
-    })(AttributeAction2 = exports2.AttributeAction || (exports2.AttributeAction = {}));
-  }
-});
-
-// node_modules/css-what/lib/commonjs/parse.js
-var require_parse3 = __commonJS({
-  "node_modules/css-what/lib/commonjs/parse.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.parse = exports2.isTraversal = void 0;
-    var types_1 = require_types();
-    var reName = /^[^\\#]?(?:\\(?:[\da-f]{1,6}\s?|.)|[\w\-\u00b0-\uFFFF])+/;
-    var reEscape = /\\([\da-f]{1,6}\s?|(\s)|.)/gi;
-    var actionTypes = /* @__PURE__ */ new Map([
-      [126, types_1.AttributeAction.Element],
-      [94, types_1.AttributeAction.Start],
-      [36, types_1.AttributeAction.End],
-      [42, types_1.AttributeAction.Any],
-      [33, types_1.AttributeAction.Not],
-      [124, types_1.AttributeAction.Hyphen]
-    ]);
-    var unpackPseudos = /* @__PURE__ */ new Set([
-      "has",
-      "not",
-      "matches",
-      "is",
-      "where",
-      "host",
-      "host-context"
-    ]);
-    function isTraversal2(selector) {
-      switch (selector.type) {
-        case types_1.SelectorType.Adjacent:
-        case types_1.SelectorType.Child:
-        case types_1.SelectorType.Descendant:
-        case types_1.SelectorType.Parent:
-        case types_1.SelectorType.Sibling:
-        case types_1.SelectorType.ColumnCombinator:
-          return true;
-        default:
-          return false;
-      }
-    }
-    exports2.isTraversal = isTraversal2;
-    var stripQuotesFromPseudos = /* @__PURE__ */ new Set(["contains", "icontains"]);
-    function funescape(_2, escaped, escapedWhitespace) {
-      var high = parseInt(escaped, 16) - 65536;
-      return high !== high || escapedWhitespace ? escaped : high < 0 ? (
-        // BMP codepoint
-        String.fromCharCode(high + 65536)
-      ) : (
-        // Supplemental Plane codepoint (surrogate pair)
-        String.fromCharCode(high >> 10 | 55296, high & 1023 | 56320)
-      );
-    }
-    function unescapeCSS(str) {
-      return str.replace(reEscape, funescape);
-    }
-    function isQuote(c) {
-      return c === 39 || c === 34;
-    }
-    function isWhitespace2(c) {
-      return c === 32 || c === 9 || c === 10 || c === 12 || c === 13;
-    }
-    function parse9(selector) {
-      var subselects2 = [];
-      var endIndex = parseSelector(subselects2, "".concat(selector), 0);
-      if (endIndex < selector.length) {
-        throw new Error("Unmatched selector: ".concat(selector.slice(endIndex)));
-      }
-      return subselects2;
-    }
-    exports2.parse = parse9;
-    function parseSelector(subselects2, selector, selectorIndex) {
-      var tokens = [];
-      function getName3(offset) {
-        var match = selector.slice(selectorIndex + offset).match(reName);
-        if (!match) {
-          throw new Error("Expected name, found ".concat(selector.slice(selectorIndex)));
-        }
-        var name = match[0];
-        selectorIndex += offset + name.length;
-        return unescapeCSS(name);
-      }
-      function stripWhitespace(offset) {
-        selectorIndex += offset;
-        while (selectorIndex < selector.length && isWhitespace2(selector.charCodeAt(selectorIndex))) {
-          selectorIndex++;
-        }
-      }
-      function readValueWithParenthesis() {
-        selectorIndex += 1;
-        var start2 = selectorIndex;
-        var counter = 1;
-        for (; counter > 0 && selectorIndex < selector.length; selectorIndex++) {
-          if (selector.charCodeAt(selectorIndex) === 40 && !isEscaped(selectorIndex)) {
-            counter++;
-          } else if (selector.charCodeAt(selectorIndex) === 41 && !isEscaped(selectorIndex)) {
-            counter--;
-          }
-        }
-        if (counter) {
-          throw new Error("Parenthesis not matched");
-        }
-        return unescapeCSS(selector.slice(start2, selectorIndex - 1));
-      }
-      function isEscaped(pos) {
-        var slashCount = 0;
-        while (selector.charCodeAt(--pos) === 92)
-          slashCount++;
-        return (slashCount & 1) === 1;
-      }
-      function ensureNotTraversal() {
-        if (tokens.length > 0 && isTraversal2(tokens[tokens.length - 1])) {
-          throw new Error("Did not expect successive traversals.");
-        }
-      }
-      function addTraversal(type2) {
-        if (tokens.length > 0 && tokens[tokens.length - 1].type === types_1.SelectorType.Descendant) {
-          tokens[tokens.length - 1].type = type2;
-          return;
-        }
-        ensureNotTraversal();
-        tokens.push({ type: type2 });
-      }
-      function addSpecialAttribute(name, action6) {
-        tokens.push({
-          type: types_1.SelectorType.Attribute,
-          name,
-          action: action6,
-          value: getName3(1),
-          namespace: null,
-          ignoreCase: "quirks"
-        });
-      }
-      function finalizeSubselector() {
-        if (tokens.length && tokens[tokens.length - 1].type === types_1.SelectorType.Descendant) {
-          tokens.pop();
-        }
-        if (tokens.length === 0) {
-          throw new Error("Empty sub-selector");
-        }
-        subselects2.push(tokens);
-      }
-      stripWhitespace(0);
-      if (selector.length === selectorIndex) {
-        return selectorIndex;
-      }
-      loop: while (selectorIndex < selector.length) {
-        var firstChar = selector.charCodeAt(selectorIndex);
-        switch (firstChar) {
-          // Whitespace
-          case 32:
-          case 9:
-          case 10:
-          case 12:
-          case 13: {
-            if (tokens.length === 0 || tokens[0].type !== types_1.SelectorType.Descendant) {
-              ensureNotTraversal();
-              tokens.push({ type: types_1.SelectorType.Descendant });
-            }
-            stripWhitespace(1);
-            break;
-          }
-          // Traversals
-          case 62: {
-            addTraversal(types_1.SelectorType.Child);
-            stripWhitespace(1);
-            break;
-          }
-          case 60: {
-            addTraversal(types_1.SelectorType.Parent);
-            stripWhitespace(1);
-            break;
-          }
-          case 126: {
-            addTraversal(types_1.SelectorType.Sibling);
-            stripWhitespace(1);
-            break;
-          }
-          case 43: {
-            addTraversal(types_1.SelectorType.Adjacent);
-            stripWhitespace(1);
-            break;
-          }
-          // Special attribute selectors: .class, #id
-          case 46: {
-            addSpecialAttribute("class", types_1.AttributeAction.Element);
-            break;
-          }
-          case 35: {
-            addSpecialAttribute("id", types_1.AttributeAction.Equals);
-            break;
-          }
-          case 91: {
-            stripWhitespace(1);
-            var name_1 = void 0;
-            var namespace = null;
-            if (selector.charCodeAt(selectorIndex) === 124) {
-              name_1 = getName3(1);
-            } else if (selector.startsWith("*|", selectorIndex)) {
-              namespace = "*";
-              name_1 = getName3(2);
-            } else {
-              name_1 = getName3(0);
-              if (selector.charCodeAt(selectorIndex) === 124 && selector.charCodeAt(selectorIndex + 1) !== 61) {
-                namespace = name_1;
-                name_1 = getName3(1);
-              }
-            }
-            stripWhitespace(0);
-            var action5 = types_1.AttributeAction.Exists;
-            var possibleAction = actionTypes.get(selector.charCodeAt(selectorIndex));
-            if (possibleAction) {
-              action5 = possibleAction;
-              if (selector.charCodeAt(selectorIndex + 1) !== 61) {
-                throw new Error("Expected `=`");
-              }
-              stripWhitespace(2);
-            } else if (selector.charCodeAt(selectorIndex) === 61) {
-              action5 = types_1.AttributeAction.Equals;
-              stripWhitespace(1);
-            }
-            var value = "";
-            var ignoreCase2 = null;
-            if (action5 !== "exists") {
-              if (isQuote(selector.charCodeAt(selectorIndex))) {
-                var quote = selector.charCodeAt(selectorIndex);
-                var sectionEnd = selectorIndex + 1;
-                while (sectionEnd < selector.length && (selector.charCodeAt(sectionEnd) !== quote || isEscaped(sectionEnd))) {
-                  sectionEnd += 1;
-                }
-                if (selector.charCodeAt(sectionEnd) !== quote) {
-                  throw new Error("Attribute value didn't end");
-                }
-                value = unescapeCSS(selector.slice(selectorIndex + 1, sectionEnd));
-                selectorIndex = sectionEnd + 1;
-              } else {
-                var valueStart = selectorIndex;
-                while (selectorIndex < selector.length && (!isWhitespace2(selector.charCodeAt(selectorIndex)) && selector.charCodeAt(selectorIndex) !== 93 || isEscaped(selectorIndex))) {
-                  selectorIndex += 1;
-                }
-                value = unescapeCSS(selector.slice(valueStart, selectorIndex));
-              }
-              stripWhitespace(0);
-              var forceIgnore = selector.charCodeAt(selectorIndex) | 32;
-              if (forceIgnore === 115) {
-                ignoreCase2 = false;
-                stripWhitespace(1);
-              } else if (forceIgnore === 105) {
-                ignoreCase2 = true;
-                stripWhitespace(1);
-              }
-            }
-            if (selector.charCodeAt(selectorIndex) !== 93) {
-              throw new Error("Attribute selector didn't terminate");
-            }
-            selectorIndex += 1;
-            var attributeSelector = {
-              type: types_1.SelectorType.Attribute,
-              name: name_1,
-              action: action5,
-              value,
-              namespace,
-              ignoreCase: ignoreCase2
-            };
-            tokens.push(attributeSelector);
-            break;
-          }
-          case 58: {
-            if (selector.charCodeAt(selectorIndex + 1) === 58) {
-              tokens.push({
-                type: types_1.SelectorType.PseudoElement,
-                name: getName3(2).toLowerCase(),
-                data: selector.charCodeAt(selectorIndex) === 40 ? readValueWithParenthesis() : null
-              });
-              continue;
-            }
-            var name_2 = getName3(1).toLowerCase();
-            var data = null;
-            if (selector.charCodeAt(selectorIndex) === 40) {
-              if (unpackPseudos.has(name_2)) {
-                if (isQuote(selector.charCodeAt(selectorIndex + 1))) {
-                  throw new Error("Pseudo-selector ".concat(name_2, " cannot be quoted"));
-                }
-                data = [];
-                selectorIndex = parseSelector(data, selector, selectorIndex + 1);
-                if (selector.charCodeAt(selectorIndex) !== 41) {
-                  throw new Error("Missing closing parenthesis in :".concat(name_2, " (").concat(selector, ")"));
-                }
-                selectorIndex += 1;
-              } else {
-                data = readValueWithParenthesis();
-                if (stripQuotesFromPseudos.has(name_2)) {
-                  var quot = data.charCodeAt(0);
-                  if (quot === data.charCodeAt(data.length - 1) && isQuote(quot)) {
-                    data = data.slice(1, -1);
-                  }
-                }
-                data = unescapeCSS(data);
-              }
-            }
-            tokens.push({ type: types_1.SelectorType.Pseudo, name: name_2, data });
-            break;
-          }
-          case 44: {
-            finalizeSubselector();
-            tokens = [];
-            stripWhitespace(1);
-            break;
-          }
-          default: {
-            if (selector.startsWith("/*", selectorIndex)) {
-              var endIndex = selector.indexOf("*/", selectorIndex + 2);
-              if (endIndex < 0) {
-                throw new Error("Comment was not terminated");
-              }
-              selectorIndex = endIndex + 2;
-              if (tokens.length === 0) {
-                stripWhitespace(0);
-              }
-              break;
-            }
-            var namespace = null;
-            var name_3 = void 0;
-            if (firstChar === 42) {
-              selectorIndex += 1;
-              name_3 = "*";
-            } else if (firstChar === 124) {
-              name_3 = "";
-              if (selector.charCodeAt(selectorIndex + 1) === 124) {
-                addTraversal(types_1.SelectorType.ColumnCombinator);
-                stripWhitespace(2);
-                break;
-              }
-            } else if (reName.test(selector.slice(selectorIndex))) {
-              name_3 = getName3(0);
-            } else {
-              break loop;
-            }
-            if (selector.charCodeAt(selectorIndex) === 124 && selector.charCodeAt(selectorIndex + 1) !== 124) {
-              namespace = name_3;
-              if (selector.charCodeAt(selectorIndex + 1) === 42) {
-                name_3 = "*";
-                selectorIndex += 2;
-              } else {
-                name_3 = getName3(1);
-              }
-            }
-            tokens.push(name_3 === "*" ? { type: types_1.SelectorType.Universal, namespace } : { type: types_1.SelectorType.Tag, name: name_3, namespace });
-          }
-        }
-      }
-      finalizeSubselector();
-      return selectorIndex;
-    }
-  }
-});
-
-// node_modules/css-what/lib/commonjs/stringify.js
-var require_stringify = __commonJS({
-  "node_modules/css-what/lib/commonjs/stringify.js"(exports2) {
-    "use strict";
-    var __spreadArray = exports2 && exports2.__spreadArray || function(to, from, pack) {
-      if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
-        if (ar || !(i in from)) {
-          if (!ar) ar = Array.prototype.slice.call(from, 0, i);
-          ar[i] = from[i];
-        }
-      }
-      return to.concat(ar || Array.prototype.slice.call(from));
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.stringify = void 0;
-    var types_1 = require_types();
-    var attribValChars = ["\\", '"'];
-    var pseudoValChars = __spreadArray(__spreadArray([], attribValChars, true), ["(", ")"], false);
-    var charsToEscapeInAttributeValue = new Set(attribValChars.map(function(c) {
-      return c.charCodeAt(0);
-    }));
-    var charsToEscapeInPseudoValue = new Set(pseudoValChars.map(function(c) {
-      return c.charCodeAt(0);
-    }));
-    var charsToEscapeInName = new Set(__spreadArray(__spreadArray([], pseudoValChars, true), [
-      "~",
-      "^",
-      "$",
-      "*",
-      "+",
-      "!",
-      "|",
-      ":",
-      "[",
-      "]",
-      " ",
-      "."
-    ], false).map(function(c) {
-      return c.charCodeAt(0);
-    }));
-    function stringify(selector) {
-      return selector.map(function(token) {
-        return token.map(stringifyToken).join("");
-      }).join(", ");
-    }
-    exports2.stringify = stringify;
-    function stringifyToken(token, index, arr) {
-      switch (token.type) {
-        // Simple types
-        case types_1.SelectorType.Child:
-          return index === 0 ? "> " : " > ";
-        case types_1.SelectorType.Parent:
-          return index === 0 ? "< " : " < ";
-        case types_1.SelectorType.Sibling:
-          return index === 0 ? "~ " : " ~ ";
-        case types_1.SelectorType.Adjacent:
-          return index === 0 ? "+ " : " + ";
-        case types_1.SelectorType.Descendant:
-          return " ";
-        case types_1.SelectorType.ColumnCombinator:
-          return index === 0 ? "|| " : " || ";
-        case types_1.SelectorType.Universal:
-          return token.namespace === "*" && index + 1 < arr.length && "name" in arr[index + 1] ? "" : "".concat(getNamespace(token.namespace), "*");
-        case types_1.SelectorType.Tag:
-          return getNamespacedName(token);
-        case types_1.SelectorType.PseudoElement:
-          return "::".concat(escapeName(token.name, charsToEscapeInName)).concat(token.data === null ? "" : "(".concat(escapeName(token.data, charsToEscapeInPseudoValue), ")"));
-        case types_1.SelectorType.Pseudo:
-          return ":".concat(escapeName(token.name, charsToEscapeInName)).concat(token.data === null ? "" : "(".concat(typeof token.data === "string" ? escapeName(token.data, charsToEscapeInPseudoValue) : stringify(token.data), ")"));
-        case types_1.SelectorType.Attribute: {
-          if (token.name === "id" && token.action === types_1.AttributeAction.Equals && token.ignoreCase === "quirks" && !token.namespace) {
-            return "#".concat(escapeName(token.value, charsToEscapeInName));
-          }
-          if (token.name === "class" && token.action === types_1.AttributeAction.Element && token.ignoreCase === "quirks" && !token.namespace) {
-            return ".".concat(escapeName(token.value, charsToEscapeInName));
-          }
-          var name_1 = getNamespacedName(token);
-          if (token.action === types_1.AttributeAction.Exists) {
-            return "[".concat(name_1, "]");
-          }
-          return "[".concat(name_1).concat(getActionValue(token.action), '="').concat(escapeName(token.value, charsToEscapeInAttributeValue), '"').concat(token.ignoreCase === null ? "" : token.ignoreCase ? " i" : " s", "]");
-        }
-      }
-    }
-    function getActionValue(action5) {
-      switch (action5) {
-        case types_1.AttributeAction.Equals:
-          return "";
-        case types_1.AttributeAction.Element:
-          return "~";
-        case types_1.AttributeAction.Start:
-          return "^";
-        case types_1.AttributeAction.End:
-          return "$";
-        case types_1.AttributeAction.Any:
-          return "*";
-        case types_1.AttributeAction.Not:
-          return "!";
-        case types_1.AttributeAction.Hyphen:
-          return "|";
-        case types_1.AttributeAction.Exists:
-          throw new Error("Shouldn't be here");
-      }
-    }
-    function getNamespacedName(token) {
-      return "".concat(getNamespace(token.namespace)).concat(escapeName(token.name, charsToEscapeInName));
-    }
-    function getNamespace(namespace) {
-      return namespace !== null ? "".concat(namespace === "*" ? "*" : escapeName(namespace, charsToEscapeInName), "|") : "";
-    }
-    function escapeName(str, charsToEscape) {
-      var lastIdx = 0;
-      var ret = "";
-      for (var i = 0; i < str.length; i++) {
-        if (charsToEscape.has(str.charCodeAt(i))) {
-          ret += "".concat(str.slice(lastIdx, i), "\\").concat(str.charAt(i));
-          lastIdx = i + 1;
-        }
-      }
-      return ret.length > 0 ? ret + str.slice(lastIdx) : str;
-    }
-  }
-});
-
-// node_modules/css-what/lib/commonjs/index.js
-var require_commonjs = __commonJS({
-  "node_modules/css-what/lib/commonjs/index.js"(exports2) {
-    "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
-      if (k2 === void 0) k2 = k;
-      var desc = Object.getOwnPropertyDescriptor(m, k);
-      if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-        desc = { enumerable: true, get: function() {
-          return m[k];
-        } };
-      }
-      Object.defineProperty(o, k2, desc);
-    }) : (function(o, m, k, k2) {
-      if (k2 === void 0) k2 = k;
-      o[k2] = m[k];
-    }));
-    var __exportStar = exports2 && exports2.__exportStar || function(m, exports3) {
-      for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports3, p)) __createBinding(exports3, m, p);
-    };
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.stringify = exports2.parse = exports2.isTraversal = void 0;
-    __exportStar(require_types(), exports2);
-    var parse_1 = require_parse3();
-    Object.defineProperty(exports2, "isTraversal", { enumerable: true, get: function() {
-      return parse_1.isTraversal;
-    } });
-    Object.defineProperty(exports2, "parse", { enumerable: true, get: function() {
-      return parse_1.parse;
-    } });
-    var stringify_1 = require_stringify();
-    Object.defineProperty(exports2, "stringify", { enumerable: true, get: function() {
-      return stringify_1.stringify;
-    } });
   }
 });
 
@@ -22218,7 +21665,7 @@ var require_CSSStyleSheet = __commonJS({
       return result;
     };
     exports2.CSSStyleSheet = CSSOM.CSSStyleSheet;
-    CSSOM.parse = require_parse4().parse;
+    CSSOM.parse = require_parse3().parse;
   }
 });
 
@@ -22883,10 +22330,10 @@ var require_CSSDocumentRule = __commonJS({
 });
 
 // node_modules/cssom/lib/parse.js
-var require_parse4 = __commonJS({
+var require_parse3 = __commonJS({
   "node_modules/cssom/lib/parse.js"(exports2) {
     var CSSOM = {};
-    CSSOM.parse = function parse9(token) {
+    CSSOM.parse = function parse8(token) {
       var i = 0;
       var state3 = "before-selector";
       var index;
@@ -23390,7 +22837,7 @@ var require_CSSStyleDeclaration = __commonJS({
       }
     };
     exports2.CSSStyleDeclaration = CSSOM.CSSStyleDeclaration;
-    CSSOM.parse = require_parse4().parse;
+    CSSOM.parse = require_parse3().parse;
   }
 });
 
@@ -23473,7 +22920,7 @@ var require_lib2 = __commonJS({
     exports2.CSSDocumentRule = require_CSSDocumentRule().CSSDocumentRule;
     exports2.CSSValue = require_CSSValue().CSSValue;
     exports2.CSSValueExpression = require_CSSValueExpression().CSSValueExpression;
-    exports2.parse = require_parse4().parse;
+    exports2.parse = require_parse3().parse;
     exports2.clone = require_clone().clone;
   }
 });
@@ -26396,7 +25843,7 @@ var require_enum_object = __commonJS({
 });
 
 // node_modules/@protobuf-ts/runtime/build/commonjs/index.js
-var require_commonjs2 = __commonJS({
+var require_commonjs = __commonJS({
   "node_modules/@protobuf-ts/runtime/build/commonjs/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -26587,7 +26034,7 @@ var require_reflection_info2 = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.readServiceOption = exports2.readMethodOption = exports2.readMethodOptions = exports2.normalizeMethodInfo = void 0;
-    var runtime_1 = require_commonjs2();
+    var runtime_1 = require_commonjs();
     function normalizeMethodInfo(method, service) {
       var _a3, _b, _c;
       let m = method;
@@ -26696,7 +26143,7 @@ var require_rpc_options = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.mergeRpcOptions = void 0;
-    var runtime_1 = require_commonjs2();
+    var runtime_1 = require_commonjs();
     function mergeRpcOptions(defaults2, options) {
       if (!options)
         return defaults2;
@@ -26833,7 +26280,7 @@ var require_rpc_output_stream = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.RpcOutputStreamController = void 0;
     var deferred_1 = require_deferred();
-    var runtime_1 = require_commonjs2();
+    var runtime_1 = require_commonjs();
     var RpcOutputStreamController = class {
       constructor() {
         this._lis = {
@@ -27288,7 +26735,7 @@ var require_test_transport = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.TestTransport = void 0;
     var rpc_error_1 = require_rpc_error();
-    var runtime_1 = require_commonjs2();
+    var runtime_1 = require_commonjs();
     var rpc_output_stream_1 = require_rpc_output_stream();
     var rpc_options_1 = require_rpc_options();
     var unary_call_1 = require_unary_call();
@@ -27532,7 +26979,7 @@ var require_rpc_interceptor = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.stackDuplexStreamingInterceptors = exports2.stackClientStreamingInterceptors = exports2.stackServerStreamingInterceptors = exports2.stackUnaryInterceptors = exports2.stackIntercept = void 0;
-    var runtime_1 = require_commonjs2();
+    var runtime_1 = require_commonjs();
     function stackIntercept(kind, transport, method, options, input) {
       var _a3, _b, _c, _d;
       if (kind == "unary") {
@@ -27656,7 +27103,7 @@ var require_server_call_context = __commonJS({
 });
 
 // node_modules/@protobuf-ts/runtime-rpc/build/commonjs/index.js
-var require_commonjs3 = __commonJS({
+var require_commonjs2 = __commonJS({
   "node_modules/@protobuf-ts/runtime-rpc/build/commonjs/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -27839,7 +27286,7 @@ var require_ms = __commonJS({
       options = options || {};
       var type2 = typeof val;
       if (type2 === "string" && val.length > 0) {
-        return parse9(val);
+        return parse8(val);
       } else if (type2 === "number" && isFinite(val)) {
         return options.long ? fmtLong(val) : fmtShort(val);
       }
@@ -27847,7 +27294,7 @@ var require_ms = __commonJS({
         "val is not a non-empty string or a valid number. val=" + JSON.stringify(val)
       );
     };
-    function parse9(str) {
+    function parse8(str) {
       str = String(str);
       if (str.length > 100) {
         return;
@@ -31408,13 +30855,13 @@ var require_async = __commonJS({
         });
       }
       function _filter(eachfn, coll, iteratee, callback) {
-        var filter4 = isArrayLike(coll) ? filterArray : filterGeneric;
-        return filter4(eachfn, coll, wrapAsync(iteratee), callback);
+        var filter5 = isArrayLike(coll) ? filterArray : filterGeneric;
+        return filter5(eachfn, coll, wrapAsync(iteratee), callback);
       }
-      function filter3(coll, iteratee, callback) {
+      function filter4(coll, iteratee, callback) {
         return _filter(eachOf$1, coll, iteratee, callback);
       }
-      var filter$1 = awaitify(filter3, 3);
+      var filter$1 = awaitify(filter4, 3);
       function filterLimit(coll, limit, iteratee, callback) {
         return _filter(eachOfLimit$2(limit), coll, iteratee, callback);
       }
@@ -41738,7 +41185,7 @@ var require_operators = __commonJS({
       }.call(this);
     }
     async function some(fn, options = void 0) {
-      for await (const unused of filter3.call(this, fn, options)) {
+      for await (const unused of filter4.call(this, fn, options)) {
         return true;
       }
       return false;
@@ -41755,8 +41202,8 @@ var require_operators = __commonJS({
         options
       );
     }
-    async function find3(fn, options) {
-      for await (const result of filter3.call(this, fn, options)) {
+    async function find4(fn, options) {
+      for await (const result of filter4.call(this, fn, options)) {
         return result;
       }
       return void 0;
@@ -41771,7 +41218,7 @@ var require_operators = __commonJS({
       }
       for await (const unused of map.call(this, forEachFn, options)) ;
     }
-    function filter3(fn, options) {
+    function filter4(fn, options) {
       if (typeof fn !== "function") {
         throw new ERR_INVALID_ARG_TYPE("fn", ["Function", "AsyncFunction"], fn);
       }
@@ -41936,7 +41383,7 @@ var require_operators = __commonJS({
     module.exports.streamReturningOperators = {
       asIndexedPairs: deprecate(asIndexedPairs, "readable.asIndexedPairs will be removed in a future version."),
       drop,
-      filter: filter3,
+      filter: filter4,
       flatMap,
       map,
       take,
@@ -41948,7 +41395,7 @@ var require_operators = __commonJS({
       reduce,
       toArray,
       some,
-      find: find3
+      find: find4
     };
   }
 });
@@ -43966,15 +43413,15 @@ var require_escape = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.escape = void 0;
-    var escape4 = (s, { windowsPathsNoEscape = false } = {}) => {
+    var escape5 = (s, { windowsPathsNoEscape = false } = {}) => {
       return windowsPathsNoEscape ? s.replace(/[?*()[\]]/g, "[$&]") : s.replace(/[?*()[\]\\]/g, "\\$&");
     };
-    exports2.escape = escape4;
+    exports2.escape = escape5;
   }
 });
 
 // node_modules/glob/node_modules/minimatch/dist/commonjs/index.js
-var require_commonjs4 = __commonJS({
+var require_commonjs3 = __commonJS({
   "node_modules/glob/node_modules/minimatch/dist/commonjs/index.js"(exports2) {
     "use strict";
     var __importDefault = exports2 && exports2.__importDefault || function(mod) {
@@ -44058,8 +43505,8 @@ var require_commonjs4 = __commonJS({
     var star = qmark + "*?";
     var twoStarDot = "(?:(?!(?:\\/|^)(?:\\.{1,2})($|\\/)).)*?";
     var twoStarNoDot = "(?:(?!(?:\\/|^)\\.).)*?";
-    var filter3 = (pattern, options = {}) => (p) => (0, exports2.minimatch)(p, pattern, options);
-    exports2.filter = filter3;
+    var filter4 = (pattern, options = {}) => (p) => (0, exports2.minimatch)(p, pattern, options);
+    exports2.filter = filter4;
     exports2.minimatch.filter = exports2.filter;
     var ext = (a, b = {}) => Object.assign({}, a, b);
     var defaults2 = (def) => {
@@ -44796,7 +44243,7 @@ var require_commonjs4 = __commonJS({
 });
 
 // node_modules/path-scurry/node_modules/lru-cache/dist/commonjs/index.js
-var require_commonjs5 = __commonJS({
+var require_commonjs4 = __commonJS({
   "node_modules/path-scurry/node_modules/lru-cache/dist/commonjs/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -46172,7 +45619,7 @@ var require_commonjs5 = __commonJS({
 });
 
 // node_modules/minipass/dist/commonjs/index.js
-var require_commonjs6 = __commonJS({
+var require_commonjs5 = __commonJS({
   "node_modules/minipass/dist/commonjs/index.js"(exports2) {
     "use strict";
     var __importDefault = exports2 && exports2.__importDefault || function(mod) {
@@ -47068,7 +46515,7 @@ var require_commonjs6 = __commonJS({
 });
 
 // node_modules/path-scurry/dist/commonjs/index.js
-var require_commonjs7 = __commonJS({
+var require_commonjs6 = __commonJS({
   "node_modules/path-scurry/dist/commonjs/index.js"(exports2) {
     "use strict";
     var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
@@ -47100,14 +46547,14 @@ var require_commonjs7 = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.PathScurry = exports2.Path = exports2.PathScurryDarwin = exports2.PathScurryPosix = exports2.PathScurryWin32 = exports2.PathScurryBase = exports2.PathPosix = exports2.PathWin32 = exports2.PathBase = exports2.ChildrenCache = exports2.ResolveCache = void 0;
-    var lru_cache_1 = require_commonjs5();
+    var lru_cache_1 = require_commonjs4();
     var node_path_1 = __require("node:path");
     var node_url_1 = __require("node:url");
     var fs_1 = __require("fs");
     var actualFS = __importStar(__require("node:fs"));
     var realpathSync = fs_1.realpathSync.native;
     var promises_1 = __require("node:fs/promises");
-    var minipass_1 = require_commonjs6();
+    var minipass_1 = require_commonjs5();
     var defaultFS = {
       lstatSync: fs_1.lstatSync,
       readdir: fs_1.readdir,
@@ -48498,9 +47945,9 @@ var require_commonjs7 = __commonJS({
           opts = entry;
           entry = this.cwd;
         }
-        const { withFileTypes = true, follow = false, filter: filter3, walkFilter } = opts;
+        const { withFileTypes = true, follow = false, filter: filter4, walkFilter } = opts;
         const results = [];
-        if (!filter3 || filter3(entry)) {
+        if (!filter4 || filter4(entry)) {
           results.push(withFileTypes ? entry : entry.fullpath());
         }
         const dirs = /* @__PURE__ */ new Set();
@@ -48519,7 +47966,7 @@ var require_commonjs7 = __commonJS({
               }
             };
             for (const e of entries2) {
-              if (!filter3 || filter3(e)) {
+              if (!filter4 || filter4(e)) {
                 results.push(withFileTypes ? e : e.fullpath());
               }
               if (follow && e.isSymbolicLink()) {
@@ -48550,16 +47997,16 @@ var require_commonjs7 = __commonJS({
           opts = entry;
           entry = this.cwd;
         }
-        const { withFileTypes = true, follow = false, filter: filter3, walkFilter } = opts;
+        const { withFileTypes = true, follow = false, filter: filter4, walkFilter } = opts;
         const results = [];
-        if (!filter3 || filter3(entry)) {
+        if (!filter4 || filter4(entry)) {
           results.push(withFileTypes ? entry : entry.fullpath());
         }
         const dirs = /* @__PURE__ */ new Set([entry]);
         for (const dir of dirs) {
           const entries2 = dir.readdirSync();
           for (const e of entries2) {
-            if (!filter3 || filter3(e)) {
+            if (!filter4 || filter4(e)) {
               results.push(withFileTypes ? e : e.fullpath());
             }
             let r = e;
@@ -48612,15 +48059,15 @@ var require_commonjs7 = __commonJS({
           opts = entry;
           entry = this.cwd;
         }
-        const { withFileTypes = true, follow = false, filter: filter3, walkFilter } = opts;
-        if (!filter3 || filter3(entry)) {
+        const { withFileTypes = true, follow = false, filter: filter4, walkFilter } = opts;
+        if (!filter4 || filter4(entry)) {
           yield withFileTypes ? entry : entry.fullpath();
         }
         const dirs = /* @__PURE__ */ new Set([entry]);
         for (const dir of dirs) {
           const entries2 = dir.readdirSync();
           for (const e of entries2) {
-            if (!filter3 || filter3(e)) {
+            if (!filter4 || filter4(e)) {
               yield withFileTypes ? e : e.fullpath();
             }
             let r = e;
@@ -48643,9 +48090,9 @@ var require_commonjs7 = __commonJS({
           opts = entry;
           entry = this.cwd;
         }
-        const { withFileTypes = true, follow = false, filter: filter3, walkFilter } = opts;
+        const { withFileTypes = true, follow = false, filter: filter4, walkFilter } = opts;
         const results = new minipass_1.Minipass({ objectMode: true });
-        if (!filter3 || filter3(entry)) {
+        if (!filter4 || filter4(entry)) {
           results.write(withFileTypes ? entry : entry.fullpath());
         }
         const dirs = /* @__PURE__ */ new Set();
@@ -48678,7 +48125,7 @@ var require_commonjs7 = __commonJS({
                 }
               }
               for (const e of entries2) {
-                if (e && (!filter3 || filter3(e))) {
+                if (e && (!filter4 || filter4(e))) {
                   if (!results.write(withFileTypes ? e : e.fullpath())) {
                     paused = true;
                   }
@@ -48712,10 +48159,10 @@ var require_commonjs7 = __commonJS({
           opts = entry;
           entry = this.cwd;
         }
-        const { withFileTypes = true, follow = false, filter: filter3, walkFilter } = opts;
+        const { withFileTypes = true, follow = false, filter: filter4, walkFilter } = opts;
         const results = new minipass_1.Minipass({ objectMode: true });
         const dirs = /* @__PURE__ */ new Set();
-        if (!filter3 || filter3(entry)) {
+        if (!filter4 || filter4(entry)) {
           results.write(withFileTypes ? entry : entry.fullpath());
         }
         const queue = [entry];
@@ -48733,7 +48180,7 @@ var require_commonjs7 = __commonJS({
             dirs.add(dir);
             const entries2 = dir.readdirSync();
             for (const e of entries2) {
-              if (!filter3 || filter3(e)) {
+              if (!filter4 || filter4(e)) {
                 if (!results.write(withFileTypes ? e : e.fullpath())) {
                   paused = true;
                 }
@@ -48847,7 +48294,7 @@ var require_pattern = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.Pattern = void 0;
-    var minimatch_1 = require_commonjs4();
+    var minimatch_1 = require_commonjs3();
     var isPatternList = (pl) => pl.length >= 1;
     var isGlobList = (gl) => gl.length >= 1;
     var Pattern = class _Pattern {
@@ -49021,7 +48468,7 @@ var require_ignore = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.Ignore = void 0;
-    var minimatch_1 = require_commonjs4();
+    var minimatch_1 = require_commonjs3();
     var pattern_js_1 = require_pattern();
     var defaultPlatform = typeof process === "object" && process && typeof process.platform === "string" ? process.platform : "linux";
     var Ignore = class {
@@ -49118,7 +48565,7 @@ var require_processor = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.Processor = exports2.SubWalks = exports2.MatchRecord = exports2.HasWalkedCache = void 0;
-    var minimatch_1 = require_commonjs4();
+    var minimatch_1 = require_commonjs3();
     var HasWalkedCache = class _HasWalkedCache {
       store;
       constructor(store = /* @__PURE__ */ new Map()) {
@@ -49351,7 +48798,7 @@ var require_walker = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.GlobStream = exports2.GlobWalker = exports2.GlobUtil = void 0;
-    var minipass_1 = require_commonjs6();
+    var minipass_1 = require_commonjs5();
     var ignore_js_1 = require_ignore();
     var processor_js_1 = require_processor();
     var makeIgnore = (ignore, opts) => typeof ignore === "string" ? new ignore_js_1.Ignore([ignore], opts) : Array.isArray(ignore) ? new ignore_js_1.Ignore(ignore, opts) : ignore;
@@ -49691,9 +49138,9 @@ var require_glob = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.Glob = void 0;
-    var minimatch_1 = require_commonjs4();
+    var minimatch_1 = require_commonjs3();
     var node_url_1 = __require("node:url");
-    var path_scurry_1 = require_commonjs7();
+    var path_scurry_1 = require_commonjs6();
     var pattern_js_1 = require_pattern();
     var walker_js_1 = require_walker();
     var defaultPlatform = typeof process === "object" && process && typeof process.platform === "string" ? process.platform : "linux";
@@ -49904,7 +49351,7 @@ var require_has_magic = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.hasMagic = void 0;
-    var minimatch_1 = require_commonjs4();
+    var minimatch_1 = require_commonjs3();
     var hasMagic = (pattern, options = {}) => {
       if (!Array.isArray(pattern)) {
         pattern = [pattern];
@@ -49920,7 +49367,7 @@ var require_has_magic = __commonJS({
 });
 
 // node_modules/glob/dist/commonjs/index.js
-var require_commonjs8 = __commonJS({
+var require_commonjs7 = __commonJS({
   "node_modules/glob/dist/commonjs/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -49930,10 +49377,10 @@ var require_commonjs8 = __commonJS({
     exports2.globSync = globSync;
     exports2.globIterateSync = globIterateSync;
     exports2.globIterate = globIterate;
-    var minimatch_1 = require_commonjs4();
+    var minimatch_1 = require_commonjs3();
     var glob_js_1 = require_glob();
     var has_magic_js_1 = require_has_magic();
-    var minimatch_2 = require_commonjs4();
+    var minimatch_2 = require_commonjs3();
     Object.defineProperty(exports2, "escape", { enumerable: true, get: function() {
       return minimatch_2.escape;
     } });
@@ -50010,7 +49457,7 @@ var require_file2 = __commonJS({
     var difference = require_difference();
     var union = require_union();
     var isPlainObject3 = require_isPlainObject();
-    var glob = require_commonjs8();
+    var glob = require_commonjs7();
     var file = module.exports = {};
     var pathSeparatorRe = /[\/\\]/g;
     var processPatterns = function(patterns, fn) {
@@ -54491,7 +53938,7 @@ var require_tar = __commonJS({
     Tar.prototype.append = function(source, data, callback) {
       var self2 = this;
       data.mtime = data.date;
-      function append3(err, sourceBuffer) {
+      function append4(err, sourceBuffer) {
         if (err) {
           callback(err);
           return;
@@ -54501,7 +53948,7 @@ var require_tar = __commonJS({
         });
       }
       if (data.sourceType === "buffer") {
-        append3(null, source);
+        append4(null, source);
       } else if (data.sourceType === "stream" && data.stats) {
         data.size = data.stats.size;
         var entry = self2.engine.entry(data, function(err) {
@@ -54509,7 +53956,7 @@ var require_tar = __commonJS({
         });
         source.pipe(entry);
       } else if (data.sourceType === "stream") {
-        util3.collectStream(source, append3);
+        util3.collectStream(source, append4);
       }
     };
     Tar.prototype.finalize = function() {
@@ -55695,7 +55142,7 @@ var require_binary = __commonJS({
             next();
           });
         };
-        self2.scan = function find3(name, search) {
+        self2.scan = function find4(name, search) {
           if (typeof search === "string") {
             search = new Buffer(search);
           } else if (!Buffer.isBuffer(search)) {
@@ -55759,7 +55206,7 @@ var require_binary = __commonJS({
       });
       return stream4;
     };
-    exports2.parse = function parse9(buffer2) {
+    exports2.parse = function parse8(buffer2) {
       var self2 = words(function(bytes, cb) {
         return function(name) {
           if (offset + bytes <= buffer2.length) {
@@ -60156,8 +59603,8 @@ function isPlainObject2(value) {
 }
 var noop = () => "";
 async function fetchWrapper(requestOptions) {
-  const fetch4 = requestOptions.request?.fetch || globalThis.fetch;
-  if (!fetch4) {
+  const fetch5 = requestOptions.request?.fetch || globalThis.fetch;
+  if (!fetch5) {
     throw new Error(
       "fetch is not set. Please pass a fetch implementation as new Octokit({ request: { fetch }}). Learn more at https://github.com/octokit/octokit.js/#fetch-missing"
     );
@@ -60173,7 +59620,7 @@ async function fetchWrapper(requestOptions) {
   );
   let fetchResponse;
   try {
-    fetchResponse = await fetch4(requestOptions.url, {
+    fetchResponse = await fetch5(requestOptions.url, {
       method: requestOptions.method,
       body: body2,
       redirect: requestOptions.request?.redirect,
@@ -65981,16 +65428,16 @@ __export(esm_exports, {
   isTag: () => isTag
 });
 var ElementType;
-(function(ElementType2) {
-  ElementType2["Root"] = "root";
-  ElementType2["Text"] = "text";
-  ElementType2["Directive"] = "directive";
-  ElementType2["Comment"] = "comment";
-  ElementType2["Script"] = "script";
-  ElementType2["Style"] = "style";
-  ElementType2["Tag"] = "tag";
-  ElementType2["CDATA"] = "cdata";
-  ElementType2["Doctype"] = "doctype";
+(function(ElementType3) {
+  ElementType3["Root"] = "root";
+  ElementType3["Text"] = "text";
+  ElementType3["Directive"] = "directive";
+  ElementType3["Comment"] = "comment";
+  ElementType3["Script"] = "script";
+  ElementType3["Style"] = "style";
+  ElementType3["Tag"] = "tag";
+  ElementType3["CDATA"] = "cdata";
+  ElementType3["Doctype"] = "doctype";
 })(ElementType || (ElementType = {}));
 function isTag(elem) {
   return elem.type === ElementType.Tag || elem.type === ElementType.Script || elem.type === ElementType.Style;
@@ -66923,7 +66370,7 @@ function encodeXML(str) {
   return ret + str.substr(lastIdx);
 }
 function getEscaper(regex, map) {
-  return function escape4(data) {
+  return function escape5(data) {
     let match;
     let lastIdx = 0;
     let result = "";
@@ -66952,17 +66399,17 @@ var escapeText = getEscaper(/[&<>\u00A0]/g, /* @__PURE__ */ new Map([
 
 // node_modules/dom-serializer/node_modules/entities/lib/esm/index.js
 var EntityLevel;
-(function(EntityLevel2) {
-  EntityLevel2[EntityLevel2["XML"] = 0] = "XML";
-  EntityLevel2[EntityLevel2["HTML"] = 1] = "HTML";
+(function(EntityLevel3) {
+  EntityLevel3[EntityLevel3["XML"] = 0] = "XML";
+  EntityLevel3[EntityLevel3["HTML"] = 1] = "HTML";
 })(EntityLevel || (EntityLevel = {}));
 var EncodingMode;
-(function(EncodingMode2) {
-  EncodingMode2[EncodingMode2["UTF8"] = 0] = "UTF8";
-  EncodingMode2[EncodingMode2["ASCII"] = 1] = "ASCII";
-  EncodingMode2[EncodingMode2["Extensive"] = 2] = "Extensive";
-  EncodingMode2[EncodingMode2["Attribute"] = 3] = "Attribute";
-  EncodingMode2[EncodingMode2["Text"] = 4] = "Text";
+(function(EncodingMode3) {
+  EncodingMode3[EncodingMode3["UTF8"] = 0] = "UTF8";
+  EncodingMode3[EncodingMode3["ASCII"] = 1] = "ASCII";
+  EncodingMode3[EncodingMode3["Extensive"] = 2] = "Extensive";
+  EncodingMode3[EncodingMode3["Attribute"] = 3] = "Attribute";
+  EncodingMode3[EncodingMode3["Text"] = 4] = "Text";
 })(EncodingMode || (EncodingMode = {}));
 
 // node_modules/dom-serializer/lib/esm/foreignNames.js
@@ -67081,14 +66528,14 @@ var unencodedElements = /* @__PURE__ */ new Set([
 function replaceQuotes(value) {
   return value.replace(/"/g, "&quot;");
 }
-function formatAttributes(attributes2, opts) {
+function formatAttributes(attributes, opts) {
   var _a3;
-  if (!attributes2)
+  if (!attributes)
     return;
   const encode = ((_a3 = opts.encodeEntities) !== null && _a3 !== void 0 ? _a3 : opts.decodeEntities) === false ? replaceQuotes : opts.xmlMode || opts.encodeEntities !== "utf8" ? encodeXML : escapeAttribute;
-  return Object.keys(attributes2).map((key2) => {
+  return Object.keys(attributes).map((key2) => {
     var _a4, _b;
-    const value = (_a4 = attributes2[key2]) !== null && _a4 !== void 0 ? _a4 : "";
+    const value = (_a4 = attributes[key2]) !== null && _a4 !== void 0 ? _a4 : "";
     if (opts.xmlMode === "foreign") {
       key2 = (_b = attributeNames.get(key2)) !== null && _b !== void 0 ? _b : key2;
     }
@@ -67545,12 +66992,12 @@ function removeSubsets(nodes) {
   return nodes;
 }
 var DocumentPosition;
-(function(DocumentPosition2) {
-  DocumentPosition2[DocumentPosition2["DISCONNECTED"] = 1] = "DISCONNECTED";
-  DocumentPosition2[DocumentPosition2["PRECEDING"] = 2] = "PRECEDING";
-  DocumentPosition2[DocumentPosition2["FOLLOWING"] = 4] = "FOLLOWING";
-  DocumentPosition2[DocumentPosition2["CONTAINS"] = 8] = "CONTAINS";
-  DocumentPosition2[DocumentPosition2["CONTAINED_BY"] = 16] = "CONTAINED_BY";
+(function(DocumentPosition3) {
+  DocumentPosition3[DocumentPosition3["DISCONNECTED"] = 1] = "DISCONNECTED";
+  DocumentPosition3[DocumentPosition3["PRECEDING"] = 2] = "PRECEDING";
+  DocumentPosition3[DocumentPosition3["FOLLOWING"] = 4] = "FOLLOWING";
+  DocumentPosition3[DocumentPosition3["CONTAINS"] = 8] = "CONTAINS";
+  DocumentPosition3[DocumentPosition3["CONTAINED_BY"] = 16] = "CONTAINED_BY";
 })(DocumentPosition || (DocumentPosition = {}));
 function compareDocumentPosition(nodeA, nodeB) {
   const aParents = [];
@@ -67931,8 +67378,8 @@ var CustomElementRegistry = class {
     if (registry.has(ce)) {
       const { Class, check } = registry.get(ce);
       if (check(element)) {
-        const { attributes: attributes2, isConnected: isConnected2 } = element;
-        for (const attr of attributes2)
+        const { attributes, isConnected: isConnected2 } = element;
+        for (const attr of attributes)
           element.removeAttributeNode(attr);
         const values = entries(element);
         for (const [key2] of values)
@@ -67941,7 +67388,7 @@ var CustomElementRegistry = class {
         ownerDocument[UPGRADE] = { element, values };
         new Class(ownerDocument, ce);
         customElements.set(element, { connected: isConnected2 });
-        for (const attr of attributes2)
+        for (const attr of attributes)
           element.setAttributeNode(attr);
         if (isConnected2 && element.connectedCallback)
           element.connectedCallback();
@@ -68017,7 +67464,7 @@ var parseFromString = (document2, isHTML, markupLanguage) => {
         document2.doctype = data.slice(name.length).trim();
     },
     // <tagName>
-    onopentag(name, attributes2) {
+    onopentag(name, attributes) {
       let create4 = true;
       if (isHTML) {
         if (ownerSVGElement) {
@@ -68029,11 +67476,11 @@ var parseFromString = (document2, isHTML, markupLanguage) => {
           node = append2(node, ownerSVGElement, active);
           create4 = false;
         } else if (active) {
-          const ce = name.includes("-") ? name : attributes2.is || "";
+          const ce = name.includes("-") ? name : attributes.is || "";
           if (ce && registry.has(ce)) {
             const { Class } = registry.get(ce);
             node = append2(node, new Class(), active);
-            delete attributes2.is;
+            delete attributes.is;
             create4 = false;
           }
         }
@@ -68041,8 +67488,8 @@ var parseFromString = (document2, isHTML, markupLanguage) => {
       if (create4)
         node = append2(node, document2.createElement(name), false);
       let end = node[END];
-      for (const name2 of keys(attributes2))
-        attribute(node, end, document2.createAttribute(name2), attributes2[name2], active);
+      for (const name2 of keys(attributes))
+        attribute(node, end, document2.createAttribute(name2), attributes[name2], active);
     },
     // #text, #comment
     oncomment(data) {
@@ -68186,7 +67633,7 @@ var attributeChangedCallback2 = (element, attributeName, oldValue) => {
         {
           childList,
           subtree,
-          attributes: attributes2,
+          attributes,
           attributeFilter,
           attributeOldValue
         }
@@ -68203,7 +67650,7 @@ var attributeChangedCallback2 = (element, attributeName, oldValue) => {
             );
             break;
           }
-        } else if (attributes2 && target === element) {
+        } else if (attributes && target === element) {
           queueAttribute(
             observer,
             element,
@@ -68962,78 +68409,1234 @@ var Comment3 = class _Comment extends CharacterData {
   }
 };
 
-// node_modules/css-select/lib/esm/index.js
-var import_boolbase6 = __toESM(require_boolbase(), 1);
-
-// node_modules/css-select/lib/esm/compile.js
-var import_css_what4 = __toESM(require_commonjs(), 1);
-var import_boolbase5 = __toESM(require_boolbase(), 1);
-
-// node_modules/css-select/lib/esm/sort.js
-var import_css_what = __toESM(require_commonjs(), 1);
-var procedure = /* @__PURE__ */ new Map([
-  [import_css_what.SelectorType.Universal, 50],
-  [import_css_what.SelectorType.Tag, 30],
-  [import_css_what.SelectorType.Attribute, 1],
-  [import_css_what.SelectorType.Pseudo, 0]
-]);
-function isTraversal(token) {
-  return !procedure.has(token.type);
+// node_modules/boolbase/dist/index.js
+function trueFunc() {
+  return true;
 }
-var attributes = /* @__PURE__ */ new Map([
-  [import_css_what.AttributeAction.Exists, 10],
-  [import_css_what.AttributeAction.Equals, 8],
-  [import_css_what.AttributeAction.Not, 7],
-  [import_css_what.AttributeAction.Start, 6],
-  [import_css_what.AttributeAction.End, 6],
-  [import_css_what.AttributeAction.Any, 5]
+function falseFunc() {
+  return false;
+}
+
+// node_modules/css-what/dist/types.js
+var SelectorType;
+(function(SelectorType2) {
+  SelectorType2["Attribute"] = "attribute";
+  SelectorType2["Pseudo"] = "pseudo";
+  SelectorType2["PseudoElement"] = "pseudo-element";
+  SelectorType2["Tag"] = "tag";
+  SelectorType2["Universal"] = "universal";
+  SelectorType2["Adjacent"] = "adjacent";
+  SelectorType2["Child"] = "child";
+  SelectorType2["Descendant"] = "descendant";
+  SelectorType2["Parent"] = "parent";
+  SelectorType2["Sibling"] = "sibling";
+  SelectorType2["ColumnCombinator"] = "column-combinator";
+})(SelectorType || (SelectorType = {}));
+var AttributeAction;
+(function(AttributeAction2) {
+  AttributeAction2["Any"] = "any";
+  AttributeAction2["Element"] = "element";
+  AttributeAction2["End"] = "end";
+  AttributeAction2["Equals"] = "equals";
+  AttributeAction2["Exists"] = "exists";
+  AttributeAction2["Hyphen"] = "hyphen";
+  AttributeAction2["Not"] = "not";
+  AttributeAction2["Start"] = "start";
+})(AttributeAction || (AttributeAction = {}));
+
+// node_modules/css-what/dist/parse.js
+var reName = /^[^#\\]?(?:\\(?:[\da-f]{1,6}\s?|.)|[\w\u00B0-\uFFFF-])+/;
+var reEscape = /\\([\da-f]{1,6}\s?|(\s)|.)/gi;
+var CharCode;
+(function(CharCode2) {
+  CharCode2[CharCode2["LeftParenthesis"] = 40] = "LeftParenthesis";
+  CharCode2[CharCode2["RightParenthesis"] = 41] = "RightParenthesis";
+  CharCode2[CharCode2["LeftSquareBracket"] = 91] = "LeftSquareBracket";
+  CharCode2[CharCode2["RightSquareBracket"] = 93] = "RightSquareBracket";
+  CharCode2[CharCode2["Comma"] = 44] = "Comma";
+  CharCode2[CharCode2["Period"] = 46] = "Period";
+  CharCode2[CharCode2["Colon"] = 58] = "Colon";
+  CharCode2[CharCode2["SingleQuote"] = 39] = "SingleQuote";
+  CharCode2[CharCode2["DoubleQuote"] = 34] = "DoubleQuote";
+  CharCode2[CharCode2["Plus"] = 43] = "Plus";
+  CharCode2[CharCode2["Tilde"] = 126] = "Tilde";
+  CharCode2[CharCode2["QuestionMark"] = 63] = "QuestionMark";
+  CharCode2[CharCode2["ExclamationMark"] = 33] = "ExclamationMark";
+  CharCode2[CharCode2["Slash"] = 47] = "Slash";
+  CharCode2[CharCode2["Equal"] = 61] = "Equal";
+  CharCode2[CharCode2["Dollar"] = 36] = "Dollar";
+  CharCode2[CharCode2["Pipe"] = 124] = "Pipe";
+  CharCode2[CharCode2["Circumflex"] = 94] = "Circumflex";
+  CharCode2[CharCode2["Asterisk"] = 42] = "Asterisk";
+  CharCode2[CharCode2["GreaterThan"] = 62] = "GreaterThan";
+  CharCode2[CharCode2["LessThan"] = 60] = "LessThan";
+  CharCode2[CharCode2["Hash"] = 35] = "Hash";
+  CharCode2[CharCode2["LowerI"] = 105] = "LowerI";
+  CharCode2[CharCode2["LowerS"] = 115] = "LowerS";
+  CharCode2[CharCode2["BackSlash"] = 92] = "BackSlash";
+  CharCode2[CharCode2["Space"] = 32] = "Space";
+  CharCode2[CharCode2["Tab"] = 9] = "Tab";
+  CharCode2[CharCode2["NewLine"] = 10] = "NewLine";
+  CharCode2[CharCode2["FormFeed"] = 12] = "FormFeed";
+  CharCode2[CharCode2["CarriageReturn"] = 13] = "CarriageReturn";
+})(CharCode || (CharCode = {}));
+var actionTypes = /* @__PURE__ */ new Map([
+  [CharCode.Tilde, AttributeAction.Element],
+  [CharCode.Circumflex, AttributeAction.Start],
+  [CharCode.Dollar, AttributeAction.End],
+  [CharCode.Asterisk, AttributeAction.Any],
+  [CharCode.ExclamationMark, AttributeAction.Not],
+  [CharCode.Pipe, AttributeAction.Hyphen]
 ]);
-function sortByProcedure(arr) {
-  const procs = arr.map(getProcedure);
-  for (let i = 1; i < arr.length; i++) {
-    const procNew = procs[i];
-    if (procNew < 0)
-      continue;
-    for (let j = i - 1; j >= 0 && procNew < procs[j]; j--) {
-      const token = arr[j + 1];
-      arr[j + 1] = arr[j];
-      arr[j] = token;
-      procs[j + 1] = procs[j];
-      procs[j] = procNew;
+var unpackPseudos = /* @__PURE__ */ new Set([
+  "has",
+  "not",
+  "matches",
+  "is",
+  "where",
+  "host",
+  "host-context"
+]);
+var pseudosToPseudoElements = /* @__PURE__ */ new Set([
+  "before",
+  "after",
+  "first-line",
+  "first-letter"
+]);
+function isTraversal(selector) {
+  switch (selector.type) {
+    case SelectorType.Adjacent:
+    case SelectorType.Child:
+    case SelectorType.Descendant:
+    case SelectorType.Parent:
+    case SelectorType.Sibling:
+    case SelectorType.ColumnCombinator: {
+      return true;
+    }
+    case SelectorType.Attribute:
+    case SelectorType.Pseudo:
+    case SelectorType.PseudoElement:
+    case SelectorType.Tag:
+    case SelectorType.Universal: {
+      return false;
     }
   }
 }
-function getProcedure(token) {
-  var _a3, _b;
-  let proc = (_a3 = procedure.get(token.type)) !== null && _a3 !== void 0 ? _a3 : -1;
-  if (token.type === import_css_what.SelectorType.Attribute) {
-    proc = (_b = attributes.get(token.action)) !== null && _b !== void 0 ? _b : 4;
-    if (token.action === import_css_what.AttributeAction.Equals && token.name === "id") {
-      proc = 9;
+var stripQuotesFromPseudos = /* @__PURE__ */ new Set(["contains", "icontains"]);
+function funescape(_2, escaped, escapedWhitespace) {
+  const high = Number.parseInt(escaped, 16) - 65536;
+  return Number.isNaN(high) || escapedWhitespace ? escaped : high < 0 ? (
+    // BMP codepoint
+    String.fromCharCode(high + 65536)
+  ) : (
+    // Supplemental Plane codepoint (surrogate pair)
+    String.fromCharCode(high >> 10 | 55296, high & 1023 | 56320)
+  );
+}
+function unescapeCSS(cssString) {
+  return cssString.replace(reEscape, funescape);
+}
+function isQuote(c) {
+  return c === CharCode.SingleQuote || c === CharCode.DoubleQuote;
+}
+function isWhitespace2(c) {
+  return c === CharCode.Space || c === CharCode.Tab || c === CharCode.NewLine || c === CharCode.FormFeed || c === CharCode.CarriageReturn;
+}
+function parse3(selector) {
+  const subselects2 = [];
+  const endIndex = parseSelector(subselects2, `${selector}`, 0);
+  if (endIndex < selector.length) {
+    throw new Error(`Unmatched selector: ${selector.slice(endIndex)}`);
+  }
+  return subselects2;
+}
+function parseSelector(subselects2, selector, selectorIndex) {
+  let tokens = [];
+  function getName4(offset) {
+    const match = selector.slice(selectorIndex + offset).match(reName);
+    if (!match) {
+      throw new Error(`Expected name, found ${selector.slice(selectorIndex)}`);
     }
-    if (token.ignoreCase) {
-      proc >>= 1;
+    const [name] = match;
+    selectorIndex += offset + name.length;
+    return unescapeCSS(name);
+  }
+  function stripWhitespace(offset) {
+    selectorIndex += offset;
+    while (selectorIndex < selector.length && isWhitespace2(selector.charCodeAt(selectorIndex))) {
+      selectorIndex++;
     }
-  } else if (token.type === import_css_what.SelectorType.Pseudo) {
-    if (!token.data) {
-      proc = 3;
-    } else if (token.name === "has" || token.name === "contains") {
-      proc = 0;
-    } else if (Array.isArray(token.data)) {
-      proc = Math.min(...token.data.map((d) => Math.min(...d.map(getProcedure))));
-      if (proc < 0) {
-        proc = 0;
+  }
+  function readValueWithParenthesis() {
+    selectorIndex += 1;
+    const start2 = selectorIndex;
+    for (let counter = 1; selectorIndex < selector.length; selectorIndex++) {
+      switch (selector.charCodeAt(selectorIndex)) {
+        case CharCode.BackSlash: {
+          selectorIndex += 1;
+          break;
+        }
+        case CharCode.LeftParenthesis: {
+          counter += 1;
+          break;
+        }
+        case CharCode.RightParenthesis: {
+          counter -= 1;
+          if (counter === 0) {
+            return unescapeCSS(selector.slice(start2, selectorIndex++));
+          }
+          break;
+        }
       }
-    } else {
-      proc = 2;
+    }
+    throw new Error("Parenthesis not matched");
+  }
+  function ensureNotTraversal() {
+    if (tokens.length > 0 && isTraversal(tokens[tokens.length - 1])) {
+      throw new Error("Did not expect successive traversals.");
     }
   }
-  return proc;
+  function addTraversal(type2) {
+    if (tokens.length > 0 && tokens[tokens.length - 1].type === SelectorType.Descendant) {
+      tokens[tokens.length - 1].type = type2;
+      return;
+    }
+    ensureNotTraversal();
+    tokens.push({ type: type2 });
+  }
+  function addSpecialAttribute(name, action5) {
+    tokens.push({
+      type: SelectorType.Attribute,
+      name,
+      action: action5,
+      value: getName4(1),
+      namespace: null,
+      ignoreCase: "quirks"
+    });
+  }
+  function finalizeSubselector() {
+    if (tokens.length > 0 && tokens[tokens.length - 1].type === SelectorType.Descendant) {
+      tokens.pop();
+    }
+    if (tokens.length === 0) {
+      throw new Error("Empty sub-selector");
+    }
+    subselects2.push(tokens);
+  }
+  stripWhitespace(0);
+  if (selector.length === selectorIndex) {
+    return selectorIndex;
+  }
+  loop: while (selectorIndex < selector.length) {
+    const firstChar = selector.charCodeAt(selectorIndex);
+    switch (firstChar) {
+      // Whitespace
+      case CharCode.Space:
+      case CharCode.Tab:
+      case CharCode.NewLine:
+      case CharCode.FormFeed:
+      case CharCode.CarriageReturn: {
+        if (tokens.length === 0 || tokens[0].type !== SelectorType.Descendant) {
+          ensureNotTraversal();
+          tokens.push({ type: SelectorType.Descendant });
+        }
+        stripWhitespace(1);
+        break;
+      }
+      // Traversals
+      case CharCode.GreaterThan: {
+        addTraversal(SelectorType.Child);
+        stripWhitespace(1);
+        break;
+      }
+      case CharCode.LessThan: {
+        addTraversal(SelectorType.Parent);
+        stripWhitespace(1);
+        break;
+      }
+      case CharCode.Tilde: {
+        addTraversal(SelectorType.Sibling);
+        stripWhitespace(1);
+        break;
+      }
+      case CharCode.Plus: {
+        addTraversal(SelectorType.Adjacent);
+        stripWhitespace(1);
+        break;
+      }
+      // Special attribute selectors: .class, #id
+      case CharCode.Period: {
+        addSpecialAttribute("class", AttributeAction.Element);
+        break;
+      }
+      case CharCode.Hash: {
+        addSpecialAttribute("id", AttributeAction.Equals);
+        break;
+      }
+      case CharCode.LeftSquareBracket: {
+        stripWhitespace(1);
+        let name;
+        let namespace = null;
+        if (selector.charCodeAt(selectorIndex) === CharCode.Pipe) {
+          name = getName4(1);
+        } else if (selector.startsWith("*|", selectorIndex)) {
+          namespace = "*";
+          name = getName4(2);
+        } else {
+          name = getName4(0);
+          if (selector.charCodeAt(selectorIndex) === CharCode.Pipe && selector.charCodeAt(selectorIndex + 1) !== CharCode.Equal) {
+            namespace = name;
+            name = getName4(1);
+          }
+        }
+        stripWhitespace(0);
+        let action5 = AttributeAction.Exists;
+        const possibleAction = actionTypes.get(selector.charCodeAt(selectorIndex));
+        if (possibleAction) {
+          action5 = possibleAction;
+          if (selector.charCodeAt(selectorIndex + 1) !== CharCode.Equal) {
+            throw new Error("Expected `=`");
+          }
+          stripWhitespace(2);
+        } else if (selector.charCodeAt(selectorIndex) === CharCode.Equal) {
+          action5 = AttributeAction.Equals;
+          stripWhitespace(1);
+        }
+        let value = "";
+        let ignoreCase2 = null;
+        if (action5 !== "exists") {
+          if (isQuote(selector.charCodeAt(selectorIndex))) {
+            const quote = selector.charCodeAt(selectorIndex);
+            selectorIndex += 1;
+            const sectionStart = selectorIndex;
+            while (selectorIndex < selector.length && selector.charCodeAt(selectorIndex) !== quote) {
+              selectorIndex += // Skip next character if it is escaped
+              selector.charCodeAt(selectorIndex) === CharCode.BackSlash ? 2 : 1;
+            }
+            if (selector.charCodeAt(selectorIndex) !== quote) {
+              throw new Error("Attribute value didn't end");
+            }
+            value = unescapeCSS(selector.slice(sectionStart, selectorIndex));
+            selectorIndex += 1;
+          } else {
+            const valueStart = selectorIndex;
+            while (selectorIndex < selector.length && !isWhitespace2(selector.charCodeAt(selectorIndex)) && selector.charCodeAt(selectorIndex) !== CharCode.RightSquareBracket) {
+              selectorIndex += // Skip next character if it is escaped
+              selector.charCodeAt(selectorIndex) === CharCode.BackSlash ? 2 : 1;
+            }
+            value = unescapeCSS(selector.slice(valueStart, selectorIndex));
+          }
+          stripWhitespace(0);
+          switch (selector.charCodeAt(selectorIndex) | 32) {
+            // If the forceIgnore flag is set (either `i` or `s`), use that value
+            case CharCode.LowerI: {
+              ignoreCase2 = true;
+              stripWhitespace(1);
+              break;
+            }
+            case CharCode.LowerS: {
+              ignoreCase2 = false;
+              stripWhitespace(1);
+              break;
+            }
+          }
+        }
+        if (selector.charCodeAt(selectorIndex) !== CharCode.RightSquareBracket) {
+          throw new Error("Attribute selector didn't terminate");
+        }
+        selectorIndex += 1;
+        const attributeSelector = {
+          type: SelectorType.Attribute,
+          name,
+          action: action5,
+          value,
+          namespace,
+          ignoreCase: ignoreCase2
+        };
+        tokens.push(attributeSelector);
+        break;
+      }
+      case CharCode.Colon: {
+        if (selector.charCodeAt(selectorIndex + 1) === CharCode.Colon) {
+          tokens.push({
+            type: SelectorType.PseudoElement,
+            name: getName4(2).toLowerCase(),
+            data: selector.charCodeAt(selectorIndex) === CharCode.LeftParenthesis ? readValueWithParenthesis() : null
+          });
+          break;
+        }
+        const name = getName4(1).toLowerCase();
+        if (pseudosToPseudoElements.has(name)) {
+          tokens.push({
+            type: SelectorType.PseudoElement,
+            name,
+            data: null
+          });
+          break;
+        }
+        let data = null;
+        if (selector.charCodeAt(selectorIndex) === CharCode.LeftParenthesis) {
+          if (unpackPseudos.has(name)) {
+            if (isQuote(selector.charCodeAt(selectorIndex + 1))) {
+              throw new Error(`Pseudo-selector ${name} cannot be quoted`);
+            }
+            data = [];
+            selectorIndex = parseSelector(data, selector, selectorIndex + 1);
+            if (selector.charCodeAt(selectorIndex) !== CharCode.RightParenthesis) {
+              throw new Error(`Missing closing parenthesis in :${name} (${selector})`);
+            }
+            selectorIndex += 1;
+          } else {
+            data = readValueWithParenthesis();
+            if (stripQuotesFromPseudos.has(name)) {
+              const quot = data.charCodeAt(0);
+              if (quot === data.charCodeAt(data.length - 1) && isQuote(quot)) {
+                data = data.slice(1, -1);
+              }
+            }
+            data = unescapeCSS(data);
+          }
+        }
+        tokens.push({ type: SelectorType.Pseudo, name, data });
+        break;
+      }
+      case CharCode.Comma: {
+        finalizeSubselector();
+        tokens = [];
+        stripWhitespace(1);
+        break;
+      }
+      default: {
+        if (selector.startsWith("/*", selectorIndex)) {
+          const endIndex = selector.indexOf("*/", selectorIndex + 2);
+          if (endIndex === -1) {
+            throw new Error("Comment was not terminated");
+          }
+          selectorIndex = endIndex + 2;
+          if (tokens.length === 0) {
+            stripWhitespace(0);
+          }
+          break;
+        }
+        let namespace = null;
+        let name;
+        if (firstChar === CharCode.Asterisk) {
+          selectorIndex += 1;
+          name = "*";
+        } else if (firstChar === CharCode.Pipe) {
+          name = "";
+          if (selector.charCodeAt(selectorIndex + 1) === CharCode.Pipe) {
+            addTraversal(SelectorType.ColumnCombinator);
+            stripWhitespace(2);
+            break;
+          }
+        } else if (reName.test(selector.slice(selectorIndex))) {
+          name = getName4(0);
+        } else {
+          break loop;
+        }
+        if (selector.charCodeAt(selectorIndex) === CharCode.Pipe && selector.charCodeAt(selectorIndex + 1) !== CharCode.Pipe) {
+          namespace = name;
+          if (selector.charCodeAt(selectorIndex + 1) === CharCode.Asterisk) {
+            name = "*";
+            selectorIndex += 2;
+          } else {
+            name = getName4(1);
+          }
+        }
+        tokens.push(name === "*" ? { type: SelectorType.Universal, namespace } : { type: SelectorType.Tag, name, namespace });
+      }
+    }
+  }
+  finalizeSubselector();
+  return selectorIndex;
 }
 
-// node_modules/css-select/lib/esm/attributes.js
-var import_boolbase = __toESM(require_boolbase(), 1);
+// node_modules/css-select/node_modules/domelementtype/dist/index.js
+var ElementType2;
+(function(ElementType3) {
+  ElementType3["Root"] = "root";
+  ElementType3["Text"] = "text";
+  ElementType3["Directive"] = "directive";
+  ElementType3["Comment"] = "comment";
+  ElementType3["Script"] = "script";
+  ElementType3["Style"] = "style";
+  ElementType3["Tag"] = "tag";
+  ElementType3["CDATA"] = "cdata";
+  ElementType3["Doctype"] = "doctype";
+})(ElementType2 || (ElementType2 = {}));
+function isTag3(element) {
+  return element.type === ElementType2.Tag || element.type === ElementType2.Script || element.type === ElementType2.Style;
+}
+var Root2 = ElementType2.Root;
+var Text3 = ElementType2.Text;
+var Directive2 = ElementType2.Directive;
+var Comment4 = ElementType2.Comment;
+var Script2 = ElementType2.Script;
+var Style2 = ElementType2.Style;
+var Tag2 = ElementType2.Tag;
+var CDATA3 = ElementType2.CDATA;
+var Doctype2 = ElementType2.Doctype;
+
+// node_modules/css-select/node_modules/domhandler/dist/node.js
+function isTag4(node) {
+  return isTag3(node);
+}
+function isCDATA2(node) {
+  return node.type === ElementType2.CDATA;
+}
+function isText2(node) {
+  return node.type === ElementType2.Text;
+}
+function isComment2(node) {
+  return node.type === ElementType2.Comment;
+}
+function hasChildren2(node) {
+  return Object.hasOwn(node, "children");
+}
+
+// node_modules/css-select/node_modules/domutils/dist/index.js
+var dist_exports2 = {};
+__export(dist_exports2, {
+  DocumentPosition: () => DocumentPosition2,
+  append: () => append3,
+  appendChild: () => appendChild2,
+  compareDocumentPosition: () => compareDocumentPosition2,
+  existsOne: () => existsOne2,
+  filter: () => filter2,
+  find: () => find2,
+  findAll: () => findAll2,
+  findOne: () => findOne2,
+  getAttributeValue: () => getAttributeValue2,
+  getChildren: () => getChildren2,
+  getElementById: () => getElementById2,
+  getElements: () => getElements2,
+  getElementsByClassName: () => getElementsByClassName2,
+  getElementsByTagName: () => getElementsByTagName2,
+  getElementsByTagType: () => getElementsByTagType2,
+  getFeed: () => getFeed2,
+  getInnerHTML: () => getInnerHTML2,
+  getName: () => getName2,
+  getOuterHTML: () => getOuterHTML2,
+  getParent: () => getParent2,
+  getSiblings: () => getSiblings2,
+  getText: () => getText2,
+  hasAttrib: () => hasAttrib2,
+  innerText: () => innerText2,
+  nextElementSibling: () => nextElementSibling3,
+  prepend: () => prepend2,
+  prependChild: () => prependChild2,
+  prevElementSibling: () => prevElementSibling2,
+  removeElement: () => removeElement2,
+  removeSubsets: () => removeSubsets2,
+  replaceElement: () => replaceElement2,
+  testElement: () => testElement2,
+  textContent: () => textContent2,
+  uniqueSort: () => uniqueSort2
+});
+
+// node_modules/css-select/node_modules/domutils/dist/querying.js
+function filter2(test, node, recurse = true, limit = Number.POSITIVE_INFINITY) {
+  return find2(test, Array.isArray(node) ? node : [node], recurse, limit);
+}
+function find2(test, nodes, recurse, limit) {
+  const result = [];
+  const nodeStack = [Array.isArray(nodes) ? nodes : [nodes]];
+  const indexStack = [0];
+  for (; ; ) {
+    if (indexStack[0] >= nodeStack[0].length) {
+      if (indexStack.length === 1) {
+        return result;
+      }
+      nodeStack.shift();
+      indexStack.shift();
+      continue;
+    }
+    const element = nodeStack[0][indexStack[0]++];
+    if (test(element)) {
+      result.push(element);
+      if (--limit <= 0)
+        return result;
+    }
+    if (recurse && hasChildren2(element) && element.children.length > 0) {
+      indexStack.unshift(0);
+      nodeStack.unshift(element.children);
+    }
+  }
+}
+function findOne2(test, nodes, recurse = true) {
+  const searchedNodes = Array.isArray(nodes) ? nodes : [nodes];
+  for (const node of searchedNodes) {
+    if (isTag4(node) && test(node)) {
+      return node;
+    }
+    if (recurse && hasChildren2(node) && node.children.length > 0) {
+      const found = findOne2(test, node.children, true);
+      if (found)
+        return found;
+    }
+  }
+  return null;
+}
+function existsOne2(test, nodes) {
+  return (Array.isArray(nodes) ? nodes : [nodes]).some((node) => isTag4(node) && test(node) || hasChildren2(node) && existsOne2(test, node.children));
+}
+function findAll2(test, nodes) {
+  const result = [];
+  const nodeStack = [Array.isArray(nodes) ? nodes : [nodes]];
+  const indexStack = [0];
+  for (; ; ) {
+    if (indexStack[0] >= nodeStack[0].length) {
+      if (nodeStack.length === 1) {
+        return result;
+      }
+      nodeStack.shift();
+      indexStack.shift();
+      continue;
+    }
+    const element = nodeStack[0][indexStack[0]++];
+    if (isTag4(element) && test(element))
+      result.push(element);
+    if (hasChildren2(element) && element.children.length > 0) {
+      indexStack.unshift(0);
+      nodeStack.unshift(element.children);
+    }
+  }
+}
+
+// node_modules/css-select/node_modules/domutils/dist/legacy.js
+var Checks2 = {
+  tag_name(name) {
+    if (typeof name === "function") {
+      return (element) => isTag4(element) && name(element.name);
+    }
+    if (name === "*") {
+      return isTag4;
+    }
+    return (element) => isTag4(element) && element.name === name;
+  },
+  tag_type(type2) {
+    if (typeof type2 === "function") {
+      return (element) => type2(element.type);
+    }
+    return (element) => element.type === type2;
+  },
+  tag_contains(data) {
+    if (typeof data === "function") {
+      return (element) => isText2(element) && data(element.data);
+    }
+    return (element) => isText2(element) && element.data === data;
+  }
+};
+function getAttribCheck2(attrib, value) {
+  if (typeof value === "function") {
+    return (element) => isTag4(element) && value(element.attribs[attrib]);
+  }
+  return (element) => isTag4(element) && element.attribs[attrib] === value;
+}
+function combineFuncs2(a, b) {
+  return (element) => a(element) || b(element);
+}
+function compileTest2(options) {
+  const funcs = Object.keys(options).map((key2) => {
+    const value = options[key2];
+    return Object.hasOwn(Checks2, key2) ? Checks2[key2](value) : getAttribCheck2(key2, value);
+  });
+  return funcs.length === 0 ? null : funcs.reduce(combineFuncs2);
+}
+function testElement2(options, node) {
+  const test = compileTest2(options);
+  return test ? test(node) : true;
+}
+function getElements2(options, nodes, recurse, limit = Number.POSITIVE_INFINITY) {
+  const test = compileTest2(options);
+  return test ? filter2(test, nodes, recurse, limit) : [];
+}
+function getElementById2(id2, nodes, recurse = true) {
+  if (!Array.isArray(nodes))
+    nodes = [nodes];
+  return findOne2(getAttribCheck2("id", id2), nodes, recurse);
+}
+function getElementsByTagName2(tagName19, nodes, recurse = true, limit = Number.POSITIVE_INFINITY) {
+  return filter2(Checks2["tag_name"](tagName19), nodes, recurse, limit);
+}
+function getElementsByClassName2(className, nodes, recurse = true, limit = Number.POSITIVE_INFINITY) {
+  return filter2(getAttribCheck2("class", className), nodes, recurse, limit);
+}
+function getElementsByTagType2(type2, nodes, recurse = true, limit = Number.POSITIVE_INFINITY) {
+  return filter2(Checks2["tag_type"](type2), nodes, recurse, limit);
+}
+
+// node_modules/entities/dist/escape.js
+var xmlCodeMap2 = /* @__PURE__ */ new Map([
+  [34, "&quot;"],
+  [38, "&amp;"],
+  [39, "&apos;"],
+  [60, "&lt;"],
+  [62, "&gt;"]
+]);
+var getCodePoint2 = typeof String.prototype.codePointAt === "function" ? (input, index) => input.codePointAt(index) : (
+  // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+  (c, index) => (c.charCodeAt(index) & 64512) === 55296 ? (c.charCodeAt(index) - 55296) * 1024 + c.charCodeAt(index + 1) - 56320 + 65536 : c.charCodeAt(index)
+);
+var XML_BITSET_VALUE = 1342177476;
+function encodeXML2(input) {
+  let out;
+  let last = 0;
+  const { length } = input;
+  for (let index = 0; index < length; index++) {
+    const char = input.charCodeAt(index);
+    if (char < 128 && ((XML_BITSET_VALUE >>> char & 1) === 0 || char >= 64 || char < 32)) {
+      continue;
+    }
+    if (out === void 0)
+      out = input.substring(0, index);
+    else if (last !== index)
+      out += input.substring(last, index);
+    if (char < 64) {
+      out += xmlCodeMap2.get(char);
+      last = index + 1;
+      continue;
+    }
+    const cp = getCodePoint2(input, index);
+    out += `&#x${cp.toString(16)};`;
+    if (cp !== char)
+      index++;
+    last = index + 1;
+  }
+  if (out === void 0)
+    return input;
+  if (last < length)
+    out += input.substr(last);
+  return out;
+}
+function getEscaper2(regex, map) {
+  return function escape5(data) {
+    let match;
+    let lastIndex = 0;
+    let result = "";
+    while (match = regex.exec(data)) {
+      if (lastIndex !== match.index) {
+        result += data.substring(lastIndex, match.index);
+      }
+      result += map.get(match[0].charCodeAt(0));
+      lastIndex = match.index + 1;
+    }
+    return result + data.substring(lastIndex);
+  };
+}
+var escapeAttribute2 = /* @__PURE__ */ getEscaper2(/["&\u00A0]/g, /* @__PURE__ */ new Map([
+  [34, "&quot;"],
+  [38, "&amp;"],
+  [160, "&nbsp;"]
+]));
+var escapeText2 = /* @__PURE__ */ getEscaper2(/[&<>\u00A0]/g, /* @__PURE__ */ new Map([
+  [38, "&amp;"],
+  [60, "&lt;"],
+  [62, "&gt;"],
+  [160, "&nbsp;"]
+]));
+
+// node_modules/entities/dist/index.js
+var EntityLevel2;
+(function(EntityLevel3) {
+  EntityLevel3[EntityLevel3["XML"] = 0] = "XML";
+  EntityLevel3[EntityLevel3["HTML"] = 1] = "HTML";
+})(EntityLevel2 || (EntityLevel2 = {}));
+var EncodingMode2;
+(function(EncodingMode3) {
+  EncodingMode3[EncodingMode3["UTF8"] = 0] = "UTF8";
+  EncodingMode3[EncodingMode3["ASCII"] = 1] = "ASCII";
+  EncodingMode3[EncodingMode3["Extensive"] = 2] = "Extensive";
+  EncodingMode3[EncodingMode3["Attribute"] = 3] = "Attribute";
+  EncodingMode3[EncodingMode3["Text"] = 4] = "Text";
+})(EncodingMode2 || (EncodingMode2 = {}));
+
+// node_modules/css-select/node_modules/dom-serializer/dist/foreign-names.js
+var elementNames2 = new Map("altGlyph altGlyphDef altGlyphItem animateColor animateMotion animateTransform clipPath feBlend feColorMatrix feComponentTransfer feComposite feConvolveMatrix feDiffuseLighting feDisplacementMap feDistantLight feDropShadow feFlood feFuncA feFuncB feFuncG feFuncR feGaussianBlur feImage feMerge feMergeNode feMorphology feOffset fePointLight feSpecularLighting feSpotLight feTile feTurbulence foreignObject glyphRef linearGradient radialGradient textPath".split(" ").map((name) => [name.toLowerCase(), name]));
+var attributeNames2 = new Map("definitionURL attributeName attributeType baseFrequency baseProfile calcMode clipPathUnits diffuseConstant edgeMode filterUnits glyphRef gradientTransform gradientUnits kernelMatrix kernelUnitLength keyPoints keySplines keyTimes lengthAdjust limitingConeAngle markerHeight markerUnits markerWidth maskContentUnits maskUnits numOctaves pathLength patternContentUnits patternTransform patternUnits pointsAtX pointsAtY pointsAtZ preserveAlpha preserveAspectRatio primitiveUnits refX refY repeatCount repeatDur requiredExtensions requiredFeatures specularConstant specularExponent spreadMethod startOffset stdDeviation stitchTiles surfaceScale systemLanguage tableValues targetX targetY textLength viewBox viewTarget xChannelSelector yChannelSelector zoomAndPan".split(" ").map((name) => [name.toLowerCase(), name]));
+
+// node_modules/css-select/node_modules/dom-serializer/dist/index.js
+var unencodedElements2 = new Set("style script xmp iframe noembed noframes plaintext noscript".split(" "));
+var voidElements2 = new Set("area base basefont br col command embed frame hr img input isindex keygen link meta param source track wbr".split(" "));
+var foreignElements2 = /* @__PURE__ */ new Set(["svg", "math"]);
+var foreignModeIntegrationPoints2 = new Set("mi mo mn ms mtext annotation-xml foreignObject desc title".split(" "));
+function render2(node, options = {}) {
+  const nodes = "length" in node ? node : [node];
+  const xmlMode = options.xmlMode ?? false;
+  let output = "";
+  for (let index = 0; index < nodes.length; index++) {
+    output += renderNode2(nodes[index], options, xmlMode);
+  }
+  return output;
+}
+var dist_default = render2;
+function renderChildren(children2, options, xmlMode) {
+  let output = "";
+  for (let index = 0; index < children2.length; index++) {
+    output += renderNode2(children2[index], options, xmlMode);
+  }
+  return output;
+}
+function renderNode2(node, options, xmlMode) {
+  switch (node.type) {
+    case Root2: {
+      return renderChildren(node.children, options, xmlMode);
+    }
+    case Directive2: {
+      return `<${node.data}>`;
+    }
+    case Comment4: {
+      return `<!--${node.data}-->`;
+    }
+    case CDATA3: {
+      return `<![CDATA[${node.children[0].data}]]>`;
+    }
+    case Script2:
+    case Style2:
+    case Tag2: {
+      return renderTag2(node, options, xmlMode);
+    }
+    case Text3: {
+      const element = node;
+      const data = element.data || "";
+      if ((options.encodeEntities ?? options.decodeEntities) !== false && !(!xmlMode && element.parent && unencodedElements2.has(element.parent.name))) {
+        return xmlMode || options.encodeEntities !== "utf8" ? encodeXML2(data) : escapeText2(data);
+      }
+      return data;
+    }
+  }
+}
+function renderTag2(element, options, xmlMode) {
+  if (xmlMode === "foreign") {
+    element.name = elementNames2.get(element.name) ?? element.name;
+    if (element.parent && foreignModeIntegrationPoints2.has(element.parent.name)) {
+      xmlMode = false;
+    }
+  }
+  if (!xmlMode && foreignElements2.has(element.name)) {
+    xmlMode = "foreign";
+  }
+  const { name, children: children2 } = element;
+  const isVoid2 = !xmlMode && voidElements2.has(name);
+  let tag = `<${name}${formatAttributes2(element.attribs, options, xmlMode)}`;
+  if (children2.length === 0 && (xmlMode ? options.selfClosingTags !== false : options.selfClosingTags && isVoid2)) {
+    tag += xmlMode ? "/>" : " />";
+  } else {
+    tag += ">";
+    if (children2.length > 0) {
+      tag += renderChildren(children2, options, xmlMode);
+    }
+    if (!isVoid2) {
+      tag += `</${name}>`;
+    }
+  }
+  return tag;
+}
+function replaceQuotes2(value) {
+  return value.replaceAll('"', "&quot;");
+}
+function formatAttributes2(attributes, options, xmlMode) {
+  if (!attributes)
+    return "";
+  const encode = (options.encodeEntities ?? options.decodeEntities) === false ? replaceQuotes2 : xmlMode || options.encodeEntities !== "utf8" ? encodeXML2 : escapeAttribute2;
+  const isForeign = xmlMode === "foreign";
+  const showEmpty = !!(options.emptyAttrs ?? xmlMode);
+  let result = "";
+  for (const key2 in attributes) {
+    if (!Object.hasOwn(attributes, key2))
+      continue;
+    const value = attributes[key2];
+    const k = isForeign ? attributeNames2.get(key2) ?? key2 : key2;
+    result += !showEmpty && (value == null || value === "") ? ` ${k}` : ` ${k}="${encode(value == null ? "" : String(value))}"`;
+  }
+  return result;
+}
+
+// node_modules/css-select/node_modules/domutils/dist/stringify.js
+function getOuterHTML2(node, options) {
+  return dist_default(node, options);
+}
+function getInnerHTML2(node, options) {
+  return hasChildren2(node) ? node.children.map((node2) => getOuterHTML2(node2, options)).join("") : "";
+}
+function getText2(node) {
+  if (Array.isArray(node))
+    return node.map(getText2).join("");
+  if (isTag4(node))
+    return node.name === "br" ? "\n" : getText2(node.children);
+  if (isCDATA2(node))
+    return getText2(node.children);
+  if (isText2(node))
+    return node.data;
+  return "";
+}
+function textContent2(node) {
+  if (Array.isArray(node))
+    return node.map(textContent2).join("");
+  if (hasChildren2(node) && !isComment2(node)) {
+    return textContent2(node.children);
+  }
+  if (isText2(node))
+    return node.data;
+  return "";
+}
+function innerText2(node) {
+  if (Array.isArray(node))
+    return node.map(innerText2).join("");
+  if (hasChildren2(node) && (node.type === ElementType2.Tag || isCDATA2(node))) {
+    return innerText2(node.children);
+  }
+  if (isText2(node))
+    return node.data;
+  return "";
+}
+
+// node_modules/css-select/node_modules/domutils/dist/feeds.js
+function getFeed2(document2) {
+  const feedRoot = getOneElement2(isValidFeed2, document2);
+  return feedRoot ? feedRoot.name === "feed" ? getAtomFeed2(feedRoot) : getRssFeed2(feedRoot) : null;
+}
+function getAtomFeed2(feedRoot) {
+  const childs = feedRoot.children;
+  const feed = {
+    type: "atom",
+    items: getElementsByTagName2("entry", childs).map((item) => {
+      const { children: children2 } = item;
+      const entry = { media: getMediaElements2(children2) };
+      addConditionally2(entry, "id", "id", children2);
+      addConditionally2(entry, "title", "title", children2);
+      const href2 = getOneElement2("link", children2)?.attribs["href"];
+      if (href2) {
+        entry.link = href2;
+      }
+      const description = fetch4("summary", children2) || fetch4("content", children2);
+      if (description) {
+        entry.description = description;
+      }
+      const pubDate = fetch4("updated", children2);
+      if (pubDate) {
+        entry.pubDate = new Date(pubDate);
+      }
+      return entry;
+    })
+  };
+  addConditionally2(feed, "id", "id", childs);
+  addConditionally2(feed, "title", "title", childs);
+  const href = getOneElement2("link", childs)?.attribs["href"];
+  if (href) {
+    feed.link = href;
+  }
+  addConditionally2(feed, "description", "subtitle", childs);
+  const updated = fetch4("updated", childs);
+  if (updated) {
+    feed.updated = new Date(updated);
+  }
+  addConditionally2(feed, "author", "email", childs, true);
+  return feed;
+}
+function getRssFeed2(feedRoot) {
+  const childs = getOneElement2("channel", feedRoot.children)?.children ?? [];
+  const feed = {
+    type: feedRoot.name.substr(0, 3),
+    id: "",
+    items: getElementsByTagName2("item", feedRoot.children).map((item) => {
+      const { children: children2 } = item;
+      const entry = { media: getMediaElements2(children2) };
+      addConditionally2(entry, "id", "guid", children2);
+      addConditionally2(entry, "title", "title", children2);
+      addConditionally2(entry, "link", "link", children2);
+      addConditionally2(entry, "description", "description", children2);
+      const pubDate = fetch4("pubDate", children2) || fetch4("dc:date", children2);
+      if (pubDate)
+        entry.pubDate = new Date(pubDate);
+      return entry;
+    })
+  };
+  addConditionally2(feed, "title", "title", childs);
+  addConditionally2(feed, "link", "link", childs);
+  addConditionally2(feed, "description", "description", childs);
+  const updated = fetch4("lastBuildDate", childs);
+  if (updated) {
+    feed.updated = new Date(updated);
+  }
+  addConditionally2(feed, "author", "managingEditor", childs, true);
+  return feed;
+}
+var MEDIA_KEYS_STRING2 = ["url", "type", "lang"];
+var MEDIA_KEYS_INT2 = [
+  "fileSize",
+  "bitrate",
+  "framerate",
+  "samplingrate",
+  "channels",
+  "duration",
+  "height",
+  "width"
+];
+function getMediaElements2(where2) {
+  return getElementsByTagName2("media:content", where2).map((element) => {
+    const { attribs } = element;
+    const media = {
+      medium: attribs["medium"],
+      isDefault: !!attribs["isDefault"]
+    };
+    for (const attrib of MEDIA_KEYS_STRING2) {
+      if (attribs[attrib]) {
+        media[attrib] = attribs[attrib];
+      }
+    }
+    for (const attrib of MEDIA_KEYS_INT2) {
+      if (attribs[attrib]) {
+        media[attrib] = Number.parseInt(attribs[attrib], 10);
+      }
+    }
+    if (attribs["expression"]) {
+      media.expression = attribs["expression"];
+    }
+    return media;
+  });
+}
+function getOneElement2(tagName19, node) {
+  return getElementsByTagName2(tagName19, node, true, 1)[0];
+}
+function fetch4(tagName19, where2, recurse = false) {
+  return textContent2(getElementsByTagName2(tagName19, where2, recurse, 1)).trim();
+}
+function addConditionally2(object, property, tagName19, where2, recurse = false) {
+  const value = fetch4(tagName19, where2, recurse);
+  if (value)
+    object[property] = value;
+}
+function isValidFeed2(value) {
+  return value === "rss" || value === "feed" || value === "rdf:RDF";
+}
+
+// node_modules/css-select/node_modules/domutils/dist/helpers.js
+function removeSubsets2(nodes) {
+  let index = nodes.length;
+  while (--index >= 0) {
+    const node = nodes[index];
+    if (index > 0 && nodes.lastIndexOf(node, index - 1) >= 0) {
+      nodes.splice(index, 1);
+      continue;
+    }
+    for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
+      if (nodes.includes(ancestor)) {
+        nodes.splice(index, 1);
+        break;
+      }
+    }
+  }
+  return nodes;
+}
+var DocumentPosition2;
+(function(DocumentPosition3) {
+  DocumentPosition3[DocumentPosition3["DISCONNECTED"] = 1] = "DISCONNECTED";
+  DocumentPosition3[DocumentPosition3["PRECEDING"] = 2] = "PRECEDING";
+  DocumentPosition3[DocumentPosition3["FOLLOWING"] = 4] = "FOLLOWING";
+  DocumentPosition3[DocumentPosition3["CONTAINS"] = 8] = "CONTAINS";
+  DocumentPosition3[DocumentPosition3["CONTAINED_BY"] = 16] = "CONTAINED_BY";
+})(DocumentPosition2 || (DocumentPosition2 = {}));
+function compareDocumentPosition2(nodeA, nodeB) {
+  const aParents = [];
+  const bParents = [];
+  if (nodeA === nodeB) {
+    return 0;
+  }
+  let current = hasChildren2(nodeA) ? nodeA : nodeA.parent;
+  while (current) {
+    aParents.unshift(current);
+    current = current.parent;
+  }
+  current = hasChildren2(nodeB) ? nodeB : nodeB.parent;
+  while (current) {
+    bParents.unshift(current);
+    current = current.parent;
+  }
+  const maxIndex = Math.min(aParents.length, bParents.length);
+  let index = 0;
+  while (index < maxIndex && aParents[index] === bParents[index]) {
+    index++;
+  }
+  if (index === 0) {
+    return DocumentPosition2.DISCONNECTED;
+  }
+  const sharedParent = aParents[index - 1];
+  const siblings = sharedParent.children;
+  const aSibling = aParents[index];
+  const bSibling = bParents[index];
+  if (siblings.indexOf(aSibling) > siblings.indexOf(bSibling)) {
+    if (sharedParent === nodeB) {
+      return DocumentPosition2.FOLLOWING | DocumentPosition2.CONTAINED_BY;
+    }
+    return DocumentPosition2.FOLLOWING;
+  }
+  if (sharedParent === nodeA) {
+    return DocumentPosition2.PRECEDING | DocumentPosition2.CONTAINS;
+  }
+  return DocumentPosition2.PRECEDING;
+}
+function uniqueSort2(nodes) {
+  nodes = nodes.filter((node, index, array2) => !array2.includes(node, index + 1));
+  nodes.sort((a, b) => {
+    const relative = compareDocumentPosition2(a, b);
+    if (relative & DocumentPosition2.PRECEDING) {
+      return -1;
+    }
+    if (relative & DocumentPosition2.FOLLOWING) {
+      return 1;
+    }
+    return 0;
+  });
+  return nodes;
+}
+
+// node_modules/css-select/node_modules/domutils/dist/manipulation.js
+function removeElement2(element) {
+  if (element.prev)
+    element.prev.next = element.next;
+  if (element.next)
+    element.next.prev = element.prev;
+  if (element.parent) {
+    const childs = element.parent.children;
+    const childsIndex = childs.lastIndexOf(element);
+    if (childsIndex !== -1) {
+      childs.splice(childsIndex, 1);
+    }
+  }
+  element.next = null;
+  element.prev = null;
+  element.parent = null;
+}
+function replaceElement2(element, replacement) {
+  replacement.prev = element.prev;
+  if (replacement.prev) {
+    replacement.prev.next = replacement;
+  }
+  replacement.next = element.next;
+  if (replacement.next) {
+    replacement.next.prev = replacement;
+  }
+  replacement.parent = element.parent;
+  if (replacement.parent) {
+    const { children: children2 } = replacement.parent;
+    const elementIndex = children2.lastIndexOf(element);
+    if (elementIndex === -1) {
+      return;
+    }
+    children2[elementIndex] = replacement;
+    element.parent = null;
+  }
+}
+function appendChild2(parent, child) {
+  removeElement2(child);
+  child.next = null;
+  child.parent = parent;
+  if (parent.children.push(child) > 1) {
+    const sibling = parent.children[parent.children.length - 2];
+    sibling.next = child;
+    child.prev = sibling;
+  } else {
+    child.prev = null;
+  }
+}
+function append3(element, next) {
+  removeElement2(next);
+  const { parent } = element;
+  const currentNext = element.next;
+  next.next = currentNext;
+  next.prev = element;
+  element.next = next;
+  next.parent = parent;
+  if (currentNext) {
+    currentNext.prev = next;
+    if (parent) {
+      const childs = parent.children;
+      childs.splice(childs.lastIndexOf(currentNext), 0, next);
+    }
+  } else if (parent) {
+    parent.children.push(next);
+  }
+}
+function prependChild2(parent, child) {
+  removeElement2(child);
+  child.parent = parent;
+  child.prev = null;
+  if (parent.children.unshift(child) === 1) {
+    child.next = null;
+  } else {
+    const sibling = parent.children[1];
+    sibling.prev = child;
+    child.next = sibling;
+  }
+}
+function prepend2(element, previous) {
+  removeElement2(previous);
+  const { parent } = element;
+  if (parent) {
+    const childs = parent.children;
+    childs.splice(childs.indexOf(element), 0, previous);
+  }
+  if (element.prev) {
+    element.prev.next = previous;
+  }
+  previous.parent = parent;
+  previous.prev = element.prev;
+  previous.next = element;
+  element.prev = previous;
+}
+
+// node_modules/css-select/node_modules/domutils/dist/traversal.js
+function getChildren2(element) {
+  return hasChildren2(element) ? element.children : [];
+}
+function getParent2(element) {
+  return element.parent || null;
+}
+function getSiblings2(element) {
+  const parent = getParent2(element);
+  if (parent != null)
+    return getChildren2(parent);
+  const siblings = [element];
+  let { prev, next } = element;
+  while (prev != null) {
+    siblings.unshift(prev);
+    ({ prev } = prev);
+  }
+  while (next != null) {
+    siblings.push(next);
+    ({ next } = next);
+  }
+  return siblings;
+}
+function getAttributeValue2(element, name) {
+  const { attribs } = element;
+  return attribs?.[name];
+}
+function hasAttrib2(element, name) {
+  const { attribs } = element;
+  return attribs != null && Object.hasOwn(attribs, name) && attribs[name] != null;
+}
+function getName2(element) {
+  return element.name;
+}
+function nextElementSibling3(element) {
+  let { next } = element;
+  while (next !== null && !isTag4(next))
+    ({ next } = next);
+  return next;
+}
+function prevElementSibling2(element) {
+  let { prev } = element;
+  while (prev !== null && !isTag4(prev))
+    ({ prev } = prev);
+  return prev;
+}
+
+// node_modules/css-select/dist/attributes.js
 var reChars = /[-[\]{}()*+?.,\\^$|#\s]/g;
+var whitespaceRe = /\s/;
 function escapeRegex(value) {
   return value.replace(reChars, "\\$&");
 }
@@ -69095,405 +69698,187 @@ var attributeRules = {
     let { value } = data;
     if (shouldIgnoreCase(data, options)) {
       value = value.toLowerCase();
-      return (elem) => {
-        const attr = adapter2.getAttributeValue(elem, name);
-        return attr != null && attr.length === value.length && attr.toLowerCase() === value && next(elem);
+      return (element) => {
+        const attribute2 = adapter2.getAttributeValue(element, name);
+        return attribute2 != null && attribute2.length === value.length && attribute2.toLowerCase() === value && next(element);
       };
     }
-    return (elem) => adapter2.getAttributeValue(elem, name) === value && next(elem);
+    return (element) => adapter2.getAttributeValue(element, name) === value && next(element);
   },
   hyphen(next, data, options) {
     const { adapter: adapter2 } = options;
     const { name } = data;
     let { value } = data;
-    const len = value.length;
+    const { length } = value;
     if (shouldIgnoreCase(data, options)) {
       value = value.toLowerCase();
-      return function hyphenIC(elem) {
-        const attr = adapter2.getAttributeValue(elem, name);
-        return attr != null && (attr.length === len || attr.charAt(len) === "-") && attr.substr(0, len).toLowerCase() === value && next(elem);
+      return function hyphenIC(element) {
+        const attribute2 = adapter2.getAttributeValue(element, name);
+        return attribute2 != null && (attribute2.length === length || attribute2.charAt(length) === "-") && attribute2.substr(0, length).toLowerCase() === value && next(element);
       };
     }
-    return function hyphen(elem) {
-      const attr = adapter2.getAttributeValue(elem, name);
-      return attr != null && (attr.length === len || attr.charAt(len) === "-") && attr.substr(0, len) === value && next(elem);
+    return function hyphen(element) {
+      const attribute2 = adapter2.getAttributeValue(element, name);
+      return attribute2 != null && (attribute2.length === length || attribute2.charAt(length) === "-") && attribute2.substr(0, length) === value && next(element);
     };
   },
   element(next, data, options) {
     const { adapter: adapter2 } = options;
     const { name, value } = data;
-    if (/\s/.test(value)) {
-      return import_boolbase.default.falseFunc;
+    if (whitespaceRe.test(value)) {
+      return falseFunc;
     }
     const regex = new RegExp(`(?:^|\\s)${escapeRegex(value)}(?:$|\\s)`, shouldIgnoreCase(data, options) ? "i" : "");
-    return function element(elem) {
-      const attr = adapter2.getAttributeValue(elem, name);
-      return attr != null && attr.length >= value.length && regex.test(attr) && next(elem);
+    return function element(node) {
+      const attribute2 = adapter2.getAttributeValue(node, name);
+      return attribute2 != null && attribute2.length >= value.length && regex.test(attribute2) && next(node);
     };
   },
   exists(next, { name }, { adapter: adapter2 }) {
-    return (elem) => adapter2.hasAttrib(elem, name) && next(elem);
+    return (element) => adapter2.hasAttrib(element, name) && next(element);
   },
   start(next, data, options) {
     const { adapter: adapter2 } = options;
     const { name } = data;
     let { value } = data;
-    const len = value.length;
-    if (len === 0) {
-      return import_boolbase.default.falseFunc;
+    const { length } = value;
+    if (length === 0) {
+      return falseFunc;
     }
     if (shouldIgnoreCase(data, options)) {
       value = value.toLowerCase();
-      return (elem) => {
-        const attr = adapter2.getAttributeValue(elem, name);
-        return attr != null && attr.length >= len && attr.substr(0, len).toLowerCase() === value && next(elem);
+      return (element) => {
+        const attribute2 = adapter2.getAttributeValue(element, name);
+        return attribute2 != null && attribute2.length >= length && attribute2.substr(0, length).toLowerCase() === value && next(element);
       };
     }
-    return (elem) => {
-      var _a3;
-      return !!((_a3 = adapter2.getAttributeValue(elem, name)) === null || _a3 === void 0 ? void 0 : _a3.startsWith(value)) && next(elem);
-    };
+    return (element) => !!adapter2.getAttributeValue(element, name)?.startsWith(value) && next(element);
   },
   end(next, data, options) {
     const { adapter: adapter2 } = options;
     const { name } = data;
     let { value } = data;
-    const len = -value.length;
-    if (len === 0) {
-      return import_boolbase.default.falseFunc;
+    const length = -value.length;
+    if (length === 0) {
+      return falseFunc;
     }
     if (shouldIgnoreCase(data, options)) {
       value = value.toLowerCase();
-      return (elem) => {
-        var _a3;
-        return ((_a3 = adapter2.getAttributeValue(elem, name)) === null || _a3 === void 0 ? void 0 : _a3.substr(len).toLowerCase()) === value && next(elem);
-      };
+      return (element) => adapter2.getAttributeValue(element, name)?.substr(length).toLowerCase() === value && next(element);
     }
-    return (elem) => {
-      var _a3;
-      return !!((_a3 = adapter2.getAttributeValue(elem, name)) === null || _a3 === void 0 ? void 0 : _a3.endsWith(value)) && next(elem);
-    };
+    return (element) => !!adapter2.getAttributeValue(element, name)?.endsWith(value) && next(element);
   },
   any(next, data, options) {
     const { adapter: adapter2 } = options;
     const { name, value } = data;
     if (value === "") {
-      return import_boolbase.default.falseFunc;
+      return falseFunc;
     }
     if (shouldIgnoreCase(data, options)) {
       const regex = new RegExp(escapeRegex(value), "i");
-      return function anyIC(elem) {
-        const attr = adapter2.getAttributeValue(elem, name);
-        return attr != null && attr.length >= value.length && regex.test(attr) && next(elem);
+      return function anyIC(element) {
+        const attribute2 = adapter2.getAttributeValue(element, name);
+        return attribute2 != null && attribute2.length >= value.length && regex.test(attribute2) && next(element);
       };
     }
-    return (elem) => {
-      var _a3;
-      return !!((_a3 = adapter2.getAttributeValue(elem, name)) === null || _a3 === void 0 ? void 0 : _a3.includes(value)) && next(elem);
-    };
+    return (element) => !!adapter2.getAttributeValue(element, name)?.includes(value) && next(element);
   },
   not(next, data, options) {
     const { adapter: adapter2 } = options;
     const { name } = data;
     let { value } = data;
     if (value === "") {
-      return (elem) => !!adapter2.getAttributeValue(elem, name) && next(elem);
-    } else if (shouldIgnoreCase(data, options)) {
+      return (element) => !!adapter2.getAttributeValue(element, name) && next(element);
+    }
+    if (shouldIgnoreCase(data, options)) {
       value = value.toLowerCase();
-      return (elem) => {
-        const attr = adapter2.getAttributeValue(elem, name);
-        return (attr == null || attr.length !== value.length || attr.toLowerCase() !== value) && next(elem);
+      return (element) => {
+        const attribute2 = adapter2.getAttributeValue(element, name);
+        return (attribute2 == null || attribute2.length !== value.length || attribute2.toLowerCase() !== value) && next(element);
       };
     }
-    return (elem) => adapter2.getAttributeValue(elem, name) !== value && next(elem);
+    return (element) => adapter2.getAttributeValue(element, name) !== value && next(element);
   }
 };
 
-// node_modules/css-select/lib/esm/pseudo-selectors/index.js
-var import_css_what2 = __toESM(require_commonjs(), 1);
-
-// node_modules/nth-check/lib/esm/parse.js
-var whitespace = /* @__PURE__ */ new Set([9, 10, 12, 13, 32]);
-var ZERO = "0".charCodeAt(0);
-var NINE = "9".charCodeAt(0);
-function parse3(formula) {
-  formula = formula.trim().toLowerCase();
-  if (formula === "even") {
-    return [2, 0];
-  } else if (formula === "odd") {
-    return [2, 1];
-  }
-  let idx = 0;
-  let a = 0;
-  let sign = readSign();
-  let number = readNumber();
-  if (idx < formula.length && formula.charAt(idx) === "n") {
-    idx++;
-    a = sign * (number !== null && number !== void 0 ? number : 1);
-    skipWhitespace2();
-    if (idx < formula.length) {
-      sign = readSign();
-      skipWhitespace2();
-      number = readNumber();
-    } else {
-      sign = number = 0;
+// node_modules/css-select/dist/helpers/querying.js
+function findAll3(query2, nodes, options) {
+  const { adapter: adapter2, xmlMode = false } = options;
+  const result = [];
+  const nodeStack = [nodes];
+  const indexStack = [0];
+  for (; ; ) {
+    if (indexStack[0] >= nodeStack[0].length) {
+      if (nodeStack.length === 1) {
+        return result;
+      }
+      nodeStack.shift();
+      indexStack.shift();
+      continue;
     }
-  }
-  if (number === null || idx < formula.length) {
-    throw new Error(`n-th rule couldn't be parsed ('${formula}')`);
-  }
-  return [a, sign * number];
-  function readSign() {
-    if (formula.charAt(idx) === "-") {
-      idx++;
-      return -1;
+    const element = nodeStack[0][indexStack[0]++];
+    if (!adapter2.isTag(element)) {
+      continue;
     }
-    if (formula.charAt(idx) === "+") {
-      idx++;
+    if (query2(element)) {
+      result.push(element);
     }
-    return 1;
-  }
-  function readNumber() {
-    const start2 = idx;
-    let value = 0;
-    while (idx < formula.length && formula.charCodeAt(idx) >= ZERO && formula.charCodeAt(idx) <= NINE) {
-      value = value * 10 + (formula.charCodeAt(idx) - ZERO);
-      idx++;
-    }
-    return idx === start2 ? null : value;
-  }
-  function skipWhitespace2() {
-    while (idx < formula.length && whitespace.has(formula.charCodeAt(idx))) {
-      idx++;
+    if (xmlMode || adapter2.getName(element) !== "template") {
+      const children2 = adapter2.getChildren(element);
+      if (children2.length > 0) {
+        nodeStack.unshift(children2);
+        indexStack.unshift(0);
+      }
     }
   }
 }
-
-// node_modules/nth-check/lib/esm/compile.js
-var import_boolbase2 = __toESM(require_boolbase(), 1);
-function compile(parsed) {
-  const a = parsed[0];
-  const b = parsed[1] - 1;
-  if (b < 0 && a <= 0)
-    return import_boolbase2.default.falseFunc;
-  if (a === -1)
-    return (index) => index <= b;
-  if (a === 0)
-    return (index) => index === b;
-  if (a === 1)
-    return b < 0 ? import_boolbase2.default.trueFunc : (index) => index >= b;
-  const absA = Math.abs(a);
-  const bMod = (b % absA + absA) % absA;
-  return a > 1 ? (index) => index >= b && index % absA === bMod : (index) => index <= b && index % absA === bMod;
-}
-
-// node_modules/nth-check/lib/esm/index.js
-function nthCheck(formula) {
-  return compile(parse3(formula));
-}
-
-// node_modules/css-select/lib/esm/pseudo-selectors/filters.js
-var import_boolbase3 = __toESM(require_boolbase(), 1);
-function getChildFunc(next, adapter2) {
-  return (elem) => {
-    const parent = adapter2.getParent(elem);
-    return parent != null && adapter2.isTag(parent) && next(elem);
-  };
-}
-var filters = {
-  contains(next, text, { adapter: adapter2 }) {
-    return function contains(elem) {
-      return next(elem) && adapter2.getText(elem).includes(text);
-    };
-  },
-  icontains(next, text, { adapter: adapter2 }) {
-    const itext = text.toLowerCase();
-    return function icontains(elem) {
-      return next(elem) && adapter2.getText(elem).toLowerCase().includes(itext);
-    };
-  },
-  // Location specific methods
-  "nth-child"(next, rule, { adapter: adapter2, equals }) {
-    const func = nthCheck(rule);
-    if (func === import_boolbase3.default.falseFunc)
-      return import_boolbase3.default.falseFunc;
-    if (func === import_boolbase3.default.trueFunc)
-      return getChildFunc(next, adapter2);
-    return function nthChild(elem) {
-      const siblings = adapter2.getSiblings(elem);
-      let pos = 0;
-      for (let i = 0; i < siblings.length; i++) {
-        if (equals(elem, siblings[i]))
-          break;
-        if (adapter2.isTag(siblings[i])) {
-          pos++;
-        }
+function findOne3(query2, nodes, options) {
+  const { adapter: adapter2, xmlMode = false } = options;
+  const nodeStack = [nodes];
+  const indexStack = [0];
+  for (; ; ) {
+    if (indexStack[0] >= nodeStack[0].length) {
+      if (nodeStack.length === 1) {
+        return null;
       }
-      return func(pos) && next(elem);
-    };
-  },
-  "nth-last-child"(next, rule, { adapter: adapter2, equals }) {
-    const func = nthCheck(rule);
-    if (func === import_boolbase3.default.falseFunc)
-      return import_boolbase3.default.falseFunc;
-    if (func === import_boolbase3.default.trueFunc)
-      return getChildFunc(next, adapter2);
-    return function nthLastChild(elem) {
-      const siblings = adapter2.getSiblings(elem);
-      let pos = 0;
-      for (let i = siblings.length - 1; i >= 0; i--) {
-        if (equals(elem, siblings[i]))
-          break;
-        if (adapter2.isTag(siblings[i])) {
-          pos++;
-        }
-      }
-      return func(pos) && next(elem);
-    };
-  },
-  "nth-of-type"(next, rule, { adapter: adapter2, equals }) {
-    const func = nthCheck(rule);
-    if (func === import_boolbase3.default.falseFunc)
-      return import_boolbase3.default.falseFunc;
-    if (func === import_boolbase3.default.trueFunc)
-      return getChildFunc(next, adapter2);
-    return function nthOfType(elem) {
-      const siblings = adapter2.getSiblings(elem);
-      let pos = 0;
-      for (let i = 0; i < siblings.length; i++) {
-        const currentSibling = siblings[i];
-        if (equals(elem, currentSibling))
-          break;
-        if (adapter2.isTag(currentSibling) && adapter2.getName(currentSibling) === adapter2.getName(elem)) {
-          pos++;
-        }
-      }
-      return func(pos) && next(elem);
-    };
-  },
-  "nth-last-of-type"(next, rule, { adapter: adapter2, equals }) {
-    const func = nthCheck(rule);
-    if (func === import_boolbase3.default.falseFunc)
-      return import_boolbase3.default.falseFunc;
-    if (func === import_boolbase3.default.trueFunc)
-      return getChildFunc(next, adapter2);
-    return function nthLastOfType(elem) {
-      const siblings = adapter2.getSiblings(elem);
-      let pos = 0;
-      for (let i = siblings.length - 1; i >= 0; i--) {
-        const currentSibling = siblings[i];
-        if (equals(elem, currentSibling))
-          break;
-        if (adapter2.isTag(currentSibling) && adapter2.getName(currentSibling) === adapter2.getName(elem)) {
-          pos++;
-        }
-      }
-      return func(pos) && next(elem);
-    };
-  },
-  // TODO determine the actual root element
-  root(next, _rule, { adapter: adapter2 }) {
-    return (elem) => {
-      const parent = adapter2.getParent(elem);
-      return (parent == null || !adapter2.isTag(parent)) && next(elem);
-    };
-  },
-  scope(next, rule, options, context5) {
-    const { equals } = options;
-    if (!context5 || context5.length === 0) {
-      return filters["root"](next, rule, options);
+      nodeStack.shift();
+      indexStack.shift();
+      continue;
     }
-    if (context5.length === 1) {
-      return (elem) => equals(context5[0], elem) && next(elem);
+    const element = nodeStack[0][indexStack[0]++];
+    if (!adapter2.isTag(element)) {
+      continue;
     }
-    return (elem) => context5.includes(elem) && next(elem);
-  },
-  hover: dynamicStatePseudo("isHovered"),
-  visited: dynamicStatePseudo("isVisited"),
-  active: dynamicStatePseudo("isActive")
-};
-function dynamicStatePseudo(name) {
-  return function dynamicPseudo(next, _rule, { adapter: adapter2 }) {
-    const func = adapter2[name];
-    if (typeof func !== "function") {
-      return import_boolbase3.default.falseFunc;
+    if (query2(element)) {
+      return element;
     }
-    return function active(elem) {
-      return func(elem) && next(elem);
-    };
-  };
-}
-
-// node_modules/css-select/lib/esm/pseudo-selectors/pseudos.js
-var pseudos = {
-  empty(elem, { adapter: adapter2 }) {
-    return !adapter2.getChildren(elem).some((elem2) => (
-      // FIXME: `getText` call is potentially expensive.
-      adapter2.isTag(elem2) || adapter2.getText(elem2) !== ""
-    ));
-  },
-  "first-child"(elem, { adapter: adapter2, equals }) {
-    if (adapter2.prevElementSibling) {
-      return adapter2.prevElementSibling(elem) == null;
-    }
-    const firstChild = adapter2.getSiblings(elem).find((elem2) => adapter2.isTag(elem2));
-    return firstChild != null && equals(elem, firstChild);
-  },
-  "last-child"(elem, { adapter: adapter2, equals }) {
-    const siblings = adapter2.getSiblings(elem);
-    for (let i = siblings.length - 1; i >= 0; i--) {
-      if (equals(elem, siblings[i]))
-        return true;
-      if (adapter2.isTag(siblings[i]))
-        break;
-    }
-    return false;
-  },
-  "first-of-type"(elem, { adapter: adapter2, equals }) {
-    const siblings = adapter2.getSiblings(elem);
-    const elemName = adapter2.getName(elem);
-    for (let i = 0; i < siblings.length; i++) {
-      const currentSibling = siblings[i];
-      if (equals(elem, currentSibling))
-        return true;
-      if (adapter2.isTag(currentSibling) && adapter2.getName(currentSibling) === elemName) {
-        break;
+    if (xmlMode || adapter2.getName(element) !== "template") {
+      const children2 = adapter2.getChildren(element);
+      if (children2.length > 0) {
+        nodeStack.unshift(children2);
+        indexStack.unshift(0);
       }
     }
-    return false;
-  },
-  "last-of-type"(elem, { adapter: adapter2, equals }) {
-    const siblings = adapter2.getSiblings(elem);
-    const elemName = adapter2.getName(elem);
-    for (let i = siblings.length - 1; i >= 0; i--) {
-      const currentSibling = siblings[i];
-      if (equals(elem, currentSibling))
-        return true;
-      if (adapter2.isTag(currentSibling) && adapter2.getName(currentSibling) === elemName) {
-        break;
-      }
-    }
-    return false;
-  },
-  "only-of-type"(elem, { adapter: adapter2, equals }) {
-    const elemName = adapter2.getName(elem);
-    return adapter2.getSiblings(elem).every((sibling) => equals(elem, sibling) || !adapter2.isTag(sibling) || adapter2.getName(sibling) !== elemName);
-  },
-  "only-child"(elem, { adapter: adapter2, equals }) {
-    return adapter2.getSiblings(elem).every((sibling) => equals(elem, sibling) || !adapter2.isTag(sibling));
-  }
-};
-function verifyPseudoArgs(func, name, subselect, argIndex) {
-  if (subselect === null) {
-    if (func.length > argIndex) {
-      throw new Error(`Pseudo-class :${name} requires an argument`);
-    }
-  } else if (func.length === argIndex) {
-    throw new Error(`Pseudo-class :${name} doesn't have any arguments`);
   }
 }
+function getNextSiblings(element, adapter2) {
+  const siblings = adapter2.getSiblings(element);
+  if (siblings.length <= 1) {
+    return [];
+  }
+  const elementIndex = siblings.indexOf(element);
+  if (elementIndex === -1 || elementIndex === siblings.length - 1) {
+    return [];
+  }
+  return siblings.slice(elementIndex + 1).filter(adapter2.isTag);
+}
+function getElementParent(node, adapter2) {
+  const parent = adapter2.getParent(node);
+  return parent != null && adapter2.isTag(parent) ? parent : null;
+}
 
-// node_modules/css-select/lib/esm/pseudo-selectors/aliases.js
+// node_modules/css-select/dist/pseudo-selectors/aliases.js
+var textControl = "input:is([type=text i],[type=search i],[type=url i],[type=tel i],[type=email i],[type=password i],[type=date i],[type=month i],[type=week i],[type=time i],[type=datetime-local i],[type=number i])";
 var aliases = {
   // Links
   "any-link": ":is(a, area, link)[href]",
@@ -69505,12 +69890,20 @@ var aliases = {
         optgroup[disabled] > option,
         fieldset[disabled]:not(fieldset[disabled] legend:first-of-type *)
     )`,
-  enabled: ":not(:disabled)",
-  checked: ":is(:is(input[type=radio], input[type=checkbox])[checked], option:selected)",
+  enabled: ":is(button, input, select, textarea, optgroup, option, fieldset):not(:disabled)",
+  checked: ":is(:is(input[type=radio], input[type=checkbox])[checked], :selected)",
   required: ":is(input, select, textarea)[required]",
   optional: ":is(input, select, textarea):not([required])",
+  "read-only": `[readonly]:is(textarea, ${textControl})`,
+  "read-write": `:not([readonly]):is(textarea, ${textControl})`,
   // JQuery extensions
-  // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-selectedness
+  /**
+   * `:selected` matches option elements that have the `selected` attribute,
+   * or are the first option element in a select element that does not have
+   * the `multiple` attribute and does not have any option elements with the
+   * `selected` attribute.
+   * @see https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-selectedness
+   */
   selected: "option:is([selected], select:not([multiple]):not(:has(> option[selected])) > :first-of-type)",
   checkbox: "[type=checkbox]",
   file: "[type=file]",
@@ -69526,38 +69919,423 @@ var aliases = {
   text: "input:is(:not([type!='']), [type=text])"
 };
 
-// node_modules/css-select/lib/esm/pseudo-selectors/subselects.js
-var import_boolbase4 = __toESM(require_boolbase(), 1);
-var PLACEHOLDER_ELEMENT = {};
-function ensureIsTag(next, adapter2) {
-  if (next === import_boolbase4.default.falseFunc)
-    return import_boolbase4.default.falseFunc;
-  return (elem) => adapter2.isTag(elem) && next(elem);
+// node_modules/nth-check/dist/compile.js
+function compile(parsed) {
+  const a = parsed[0];
+  const b = parsed[1] - 1;
+  if (b < 0 && a <= 0)
+    return falseFunc;
+  if (a === -1)
+    return (index) => index <= b;
+  if (a === 0)
+    return (index) => index === b;
+  if (a === 1)
+    return b < 0 ? trueFunc : (index) => index >= b;
+  const absA = Math.abs(a);
+  const bModulo = (b % absA + absA) % absA;
+  return a > 1 ? (index) => index >= b && index % absA === bModulo : (index) => index <= b && index % absA === bModulo;
 }
-function getNextSiblings(elem, adapter2) {
-  const siblings = adapter2.getSiblings(elem);
-  if (siblings.length <= 1)
-    return [];
-  const elemIndex = siblings.indexOf(elem);
-  if (elemIndex < 0 || elemIndex === siblings.length - 1)
-    return [];
-  return siblings.slice(elemIndex + 1).filter(adapter2.isTag);
+
+// node_modules/nth-check/dist/parse.js
+var whitespace = /* @__PURE__ */ new Set([9, 10, 12, 13, 32]);
+var ZERO = "0".charCodeAt(0);
+var NINE = "9".charCodeAt(0);
+function parse4(formula) {
+  formula = formula.trim().toLowerCase();
+  switch (formula) {
+    case "even": {
+      return [2, 0];
+    }
+    case "odd": {
+      return [2, 1];
+    }
+  }
+  let index = 0;
+  let a = 0;
+  let sign = readSign();
+  let number = readNumber();
+  if (index < formula.length && formula.charAt(index) === "n") {
+    index++;
+    a = sign * (number ?? 1);
+    skipWhitespace2();
+    if (index < formula.length) {
+      sign = readSign();
+      skipWhitespace2();
+      number = readNumber();
+    } else {
+      sign = number = 0;
+    }
+  }
+  if (number === null || index < formula.length) {
+    throw new Error(`n-th rule couldn't be parsed ('${formula}')`);
+  }
+  return [a, sign * number];
+  function readSign() {
+    switch (formula.charAt(index)) {
+      case "-": {
+        index++;
+        return -1;
+      }
+      case "+": {
+        index++;
+        break;
+      }
+    }
+    return 1;
+  }
+  function readNumber() {
+    const start2 = index;
+    let value = 0;
+    while (index < formula.length && formula.charCodeAt(index) >= ZERO && formula.charCodeAt(index) <= NINE) {
+      value = value * 10 + (formula.charCodeAt(index) - ZERO);
+      index++;
+    }
+    return index === start2 ? null : value;
+  }
+  function skipWhitespace2() {
+    while (index < formula.length && whitespace.has(formula.charCodeAt(index))) {
+      index++;
+    }
+  }
 }
-function copyOptions(options) {
-  return {
-    xmlMode: !!options.xmlMode,
-    lowerCaseAttributeNames: !!options.lowerCaseAttributeNames,
-    lowerCaseTags: !!options.lowerCaseTags,
-    quirksMode: !!options.quirksMode,
-    cacheResults: !!options.cacheResults,
-    pseudos: options.pseudos,
-    adapter: options.adapter,
-    equals: options.equals
+
+// node_modules/nth-check/dist/index.js
+function nthCheck(formula) {
+  return compile(parse4(formula));
+}
+
+// node_modules/css-select/dist/helpers/cache.js
+function cacheParentResults(next, { adapter: adapter2, cacheResults }, matches2) {
+  if (cacheResults === false || typeof WeakMap === "undefined") {
+    return (element) => next(element) && matches2(element);
+  }
+  const resultCache = /* @__PURE__ */ new WeakMap();
+  function addResultToCache(element) {
+    const result = matches2(element);
+    resultCache.set(element, result);
+    return result;
+  }
+  return function cachedMatcher(element) {
+    if (!next(element)) {
+      return false;
+    }
+    if (resultCache.has(element)) {
+      return resultCache.get(element) ?? false;
+    }
+    let node = element;
+    do {
+      const parent = getElementParent(node, adapter2);
+      if (parent === null) {
+        return addResultToCache(element);
+      }
+      node = parent;
+    } while (!resultCache.has(node));
+    return resultCache.get(node) ? addResultToCache(element) : false;
   };
 }
+
+// node_modules/css-select/dist/helpers/options.js
+function copyOptions(options) {
+  const { context: _2, rootFunc: __, ...copied } = options;
+  return copied;
+}
+
+// node_modules/css-select/dist/pseudo-selectors/filters.js
+function extendedFilter(tag, range2) {
+  if (range2[0] !== "*" && range2[0] !== tag[0])
+    return false;
+  let tagIndex = 1;
+  for (let rangeIndex = 1; rangeIndex < range2.length; rangeIndex++) {
+    if (range2[rangeIndex] === "*")
+      continue;
+    while (tagIndex < tag.length && tag[tagIndex] !== range2[rangeIndex]) {
+      if (tag[tagIndex++].length <= 1)
+        return false;
+    }
+    if (tagIndex >= tag.length)
+      return false;
+    tagIndex++;
+  }
+  return true;
+}
+var nthOfRegex = /^(.+?)\s+of\s+(.+)$/is;
+function compileNth(reverse, ofType) {
+  return function nth(next, rule, options, context5, compileToken2) {
+    const { adapter: adapter2, equals } = options;
+    const ofMatch = ofType ? null : rule.match(nthOfRegex);
+    const nthCheck2 = nthCheck(ofMatch ? ofMatch[1].trim() : rule);
+    if (nthCheck2 === falseFunc)
+      return falseFunc;
+    const ofSelector = ofMatch && compileToken2 ? compileToken2(parse3(ofMatch[2].trim()), copyOptions(options), context5) : void 0;
+    if (ofSelector === falseFunc)
+      return falseFunc;
+    if (nthCheck2 === trueFunc && !ofSelector) {
+      return (element) => getElementParent(element, adapter2) !== null && next(element);
+    }
+    const shouldCount = ofSelector ? (_element, sibling) => ofSelector(sibling) : ofType ? (element, sibling) => adapter2.getName(sibling) === adapter2.getName(element) : trueFunc;
+    if (reverse) {
+      return function nthLast(element) {
+        if (ofSelector && !ofSelector(element))
+          return false;
+        const siblings = adapter2.getSiblings(element);
+        let pos = 0;
+        for (let index = siblings.length - 1; index >= 0; index--) {
+          const sibling = siblings[index];
+          if (equals(element, sibling))
+            break;
+          if (adapter2.isTag(sibling) && shouldCount(element, sibling))
+            pos++;
+        }
+        return nthCheck2(pos) && next(element);
+      };
+    }
+    return function nth2(element) {
+      if (ofSelector && !ofSelector(element))
+        return false;
+      const siblings = adapter2.getSiblings(element);
+      let pos = 0;
+      for (const sibling of siblings) {
+        if (equals(element, sibling))
+          break;
+        if (adapter2.isTag(sibling) && shouldCount(element, sibling))
+          pos++;
+      }
+      return nthCheck2(pos) && next(element);
+    };
+  };
+}
+var filters = {
+  contains(next, text, options) {
+    const { getText: getText4 } = options.adapter;
+    return cacheParentResults(next, options, (element) => getText4(element).includes(text));
+  },
+  icontains(next, text, options) {
+    const itext = text.toLowerCase();
+    const { getText: getText4 } = options.adapter;
+    return cacheParentResults(next, options, (element) => getText4(element).toLowerCase().includes(itext));
+  },
+  // Location specific methods
+  "nth-child": compileNth(false, false),
+  "nth-last-child": compileNth(true, false),
+  "nth-of-type": compileNth(false, true),
+  "nth-last-of-type": compileNth(true, true),
+  // TODO determine the actual root element
+  root(next, _rule, { adapter: adapter2 }) {
+    return (element) => getElementParent(element, adapter2) === null && next(element);
+  },
+  scope(next, rule, options, context5) {
+    const { equals } = options;
+    if (!context5 || context5.length === 0) {
+      return filters["root"](next, rule, options);
+    }
+    if (context5.length === 1) {
+      return (element) => equals(context5[0], element) && next(element);
+    }
+    return (element) => context5.includes(element) && next(element);
+  },
+  lang(next, code, { adapter: adapter2 }) {
+    const ranges = code.split(",").map((r) => r.trim()).filter((r) => r.length > 0).map((r) => r.replace(/^['"]|['"]$/g, "").toLowerCase().split("-"));
+    return function lang(element) {
+      let node = element;
+      while (node != null) {
+        const value = adapter2.getAttributeValue(node, "xml:lang") ?? adapter2.getAttributeValue(node, "lang");
+        if (value != null) {
+          if (!value) {
+            return ranges.some((r) => r[0] === "") && next(element);
+          }
+          const tag = value.toLowerCase().split("-");
+          return ranges.some((r) => extendedFilter(tag, r)) && next(element);
+        }
+        const parent = adapter2.getParent(node);
+        node = parent != null && adapter2.isTag(parent) ? parent : null;
+      }
+      return ranges.some((r) => r[0] === "") && next(element);
+    };
+  },
+  hover: dynamicStatePseudo("isHovered"),
+  visited: dynamicStatePseudo("isVisited"),
+  active: dynamicStatePseudo("isActive")
+};
+function dynamicStatePseudo(name) {
+  return function dynamicPseudo(next, _rule, { adapter: adapter2 }) {
+    const filterFunction = adapter2[name];
+    if (typeof filterFunction !== "function") {
+      return falseFunc;
+    }
+    return function active(element) {
+      return filterFunction(element) && next(element);
+    };
+  };
+}
+
+// node_modules/css-select/dist/pseudo-selectors/pseudos.js
+var isDocumentWhiteSpace = /^[ \t\r\n]*$/;
+var pseudos = {
+  empty(element, { adapter: adapter2 }) {
+    const children2 = adapter2.getChildren(element);
+    return (
+      // First, make sure the tag does not have any element children.
+      children2.every((element2) => !adapter2.isTag(element2)) && // Then, check that the text content is only whitespace.
+      children2.every((element2) => (
+        // FIXME: `getText` call is potentially expensive.
+        isDocumentWhiteSpace.test(adapter2.getText(element2))
+      ))
+    );
+  },
+  "first-child"(element, { adapter: adapter2, equals }) {
+    if (adapter2.prevElementSibling) {
+      return adapter2.prevElementSibling(element) == null;
+    }
+    const firstChild = adapter2.getSiblings(element).find((sibling) => adapter2.isTag(sibling));
+    return firstChild != null && equals(element, firstChild);
+  },
+  "last-child"(element, { adapter: adapter2, equals }) {
+    const siblings = adapter2.getSiblings(element);
+    for (let index = siblings.length - 1; index >= 0; index--) {
+      if (equals(element, siblings[index])) {
+        return true;
+      }
+      if (adapter2.isTag(siblings[index])) {
+        break;
+      }
+    }
+    return false;
+  },
+  "first-of-type"(element, { adapter: adapter2, equals }) {
+    const siblings = adapter2.getSiblings(element);
+    const elementName = adapter2.getName(element);
+    for (const currentSibling of siblings) {
+      if (equals(element, currentSibling)) {
+        return true;
+      }
+      if (adapter2.isTag(currentSibling) && adapter2.getName(currentSibling) === elementName) {
+        break;
+      }
+    }
+    return false;
+  },
+  "last-of-type"(element, { adapter: adapter2, equals }) {
+    const siblings = adapter2.getSiblings(element);
+    const elementName = adapter2.getName(element);
+    for (let index = siblings.length - 1; index >= 0; index--) {
+      const currentSibling = siblings[index];
+      if (equals(element, currentSibling)) {
+        return true;
+      }
+      if (adapter2.isTag(currentSibling) && adapter2.getName(currentSibling) === elementName) {
+        break;
+      }
+    }
+    return false;
+  },
+  "only-of-type"(element, { adapter: adapter2, equals }) {
+    const elementName = adapter2.getName(element);
+    return adapter2.getSiblings(element).every((sibling) => equals(element, sibling) || !adapter2.isTag(sibling) || adapter2.getName(sibling) !== elementName);
+  },
+  "only-child"(element, { adapter: adapter2, equals }) {
+    return adapter2.getSiblings(element).every((sibling) => equals(element, sibling) || !adapter2.isTag(sibling));
+  }
+};
+function verifyPseudoArguments(pseudoClassCondition, name, subselect, argumentIndex) {
+  if (subselect === null) {
+    if (pseudoClassCondition.length > argumentIndex) {
+      throw new Error(`Pseudo-class :${name} requires an argument`);
+    }
+  } else if (pseudoClassCondition.length === argumentIndex) {
+    throw new Error(`Pseudo-class :${name} doesn't have any arguments`);
+  }
+}
+
+// node_modules/css-select/dist/helpers/selectors.js
+function isTraversal2(token) {
+  return token.type === "_flexibleDescendant" || isTraversal(token);
+}
+function sortRules(array2) {
+  const ratings = array2.map(getQuality);
+  for (let index = 1; index < array2.length; index++) {
+    const procNew = ratings[index];
+    if (procNew < 0) {
+      continue;
+    }
+    for (let currentIndex = index; currentIndex > 0 && procNew < ratings[currentIndex - 1]; currentIndex--) {
+      const token = array2[currentIndex];
+      array2[currentIndex] = array2[currentIndex - 1];
+      array2[currentIndex - 1] = token;
+      ratings[currentIndex] = ratings[currentIndex - 1];
+      ratings[currentIndex - 1] = procNew;
+    }
+  }
+}
+function getAttributeQuality(token) {
+  switch (token.action) {
+    case AttributeAction.Exists: {
+      return 10;
+    }
+    case AttributeAction.Equals: {
+      return token.name === "id" ? 9 : 8;
+    }
+    case AttributeAction.Not: {
+      return 7;
+    }
+    case AttributeAction.Start: {
+      return 6;
+    }
+    case AttributeAction.End: {
+      return 6;
+    }
+    case AttributeAction.Any: {
+      return 5;
+    }
+    case AttributeAction.Hyphen: {
+      return 4;
+    }
+    case AttributeAction.Element: {
+      return 3;
+    }
+  }
+}
+function getQuality(token) {
+  switch (token.type) {
+    case SelectorType.Universal: {
+      return 50;
+    }
+    case SelectorType.Tag: {
+      return 30;
+    }
+    case SelectorType.Attribute: {
+      return Math.floor(getAttributeQuality(token) / // `ignoreCase` adds some overhead, half the result if applicable.
+      (token.ignoreCase ? 2 : 1));
+    }
+    case SelectorType.Pseudo: {
+      return token.data ? token.name === "has" || token.name === "contains" || token.name === "icontains" ? (
+        // Expensive in any case — run as late as possible.
+        0
+      ) : Array.isArray(token.data) ? (
+        // Eg. `:is`, `:not`
+        Math.max(
+          // If we have traversals, try to avoid executing this selector
+          0,
+          Math.min(...token.data.map((d) => Math.min(...d.map(getQuality))))
+        )
+      ) : 2 : 3;
+    }
+    default: {
+      return -1;
+    }
+  }
+}
+function includesScopePseudo(t) {
+  return t.type === SelectorType.Pseudo && (t.name === "scope" || Array.isArray(t.data) && t.data.some((data) => data.some(includesScopePseudo)));
+}
+
+// node_modules/css-select/dist/pseudo-selectors/subselects.js
+var PLACEHOLDER_ELEMENT = {};
+function hasDependsOnCurrentElement(selector) {
+  return selector.some((sel) => sel.length > 0 && (isTraversal2(sel[0]) || sel.some(includesScopePseudo)));
+}
 var is = (next, token, options, context5, compileToken2) => {
-  const func = compileToken2(token, copyOptions(options), context5);
-  return func === import_boolbase4.default.trueFunc ? next : func === import_boolbase4.default.falseFunc ? import_boolbase4.default.falseFunc : (elem) => func(elem) && next(elem);
+  const compiledToken = compileToken2(token, copyOptions(options), context5);
+  return compiledToken === trueFunc ? next : compiledToken === falseFunc ? falseFunc : (element) => compiledToken(element) && next(element);
 };
 var subselects = {
   is,
@@ -69567,39 +70345,45 @@ var subselects = {
   matches: is,
   where: is,
   not(next, token, options, context5, compileToken2) {
-    const func = compileToken2(token, copyOptions(options), context5);
-    return func === import_boolbase4.default.falseFunc ? next : func === import_boolbase4.default.trueFunc ? import_boolbase4.default.falseFunc : (elem) => !func(elem) && next(elem);
+    const compiledToken = compileToken2(token, copyOptions(options), context5);
+    return compiledToken === falseFunc ? next : compiledToken === trueFunc ? falseFunc : (element) => !compiledToken(element) && next(element);
   },
   has(next, subselect, options, _context, compileToken2) {
     const { adapter: adapter2 } = options;
-    const opts = copyOptions(options);
-    opts.relativeSelector = true;
-    const context5 = subselect.some((s) => s.some(isTraversal)) ? (
+    const copiedOptions = copyOptions(options);
+    copiedOptions.relativeSelector = true;
+    const context5 = subselect.some((s) => s.some(isTraversal2)) ? (
       // Used as a placeholder. Will be replaced with the actual element.
       [PLACEHOLDER_ELEMENT]
     ) : void 0;
-    const compiled = compileToken2(subselect, opts, context5);
-    if (compiled === import_boolbase4.default.falseFunc)
-      return import_boolbase4.default.falseFunc;
-    const hasElement = ensureIsTag(compiled, adapter2);
-    if (context5 && compiled !== import_boolbase4.default.trueFunc) {
-      const { shouldTestNextSiblings = false } = compiled;
-      return (elem) => {
-        if (!next(elem))
-          return false;
-        context5[0] = elem;
-        const childs = adapter2.getChildren(elem);
-        const nextElements = shouldTestNextSiblings ? [...childs, ...getNextSiblings(elem, adapter2)] : childs;
-        return adapter2.existsOne(hasElement, nextElements);
-      };
+    const skipCache = hasDependsOnCurrentElement(subselect);
+    const compiled = compileToken2(subselect, copiedOptions, context5);
+    if (compiled === falseFunc) {
+      return falseFunc;
     }
-    return (elem) => next(elem) && adapter2.existsOne(hasElement, adapter2.getChildren(elem));
+    if (context5 && compiled !== trueFunc) {
+      return skipCache ? (element) => {
+        if (!next(element)) {
+          return false;
+        }
+        context5[0] = element;
+        const childs = adapter2.getChildren(element);
+        return findOne3(compiled, compiled.shouldTestNextSiblings ? [
+          ...childs,
+          ...getNextSiblings(element, adapter2)
+        ] : childs, options) !== null;
+      } : cacheParentResults(next, options, (element) => {
+        context5[0] = element;
+        return findOne3(compiled, adapter2.getChildren(element), options) !== null;
+      });
+    }
+    const hasOne = (element) => findOne3(compiled, adapter2.getChildren(element), options) !== null;
+    return skipCache ? (element) => next(element) && hasOne(element) : cacheParentResults(next, options, hasOne);
   }
 };
 
-// node_modules/css-select/lib/esm/pseudo-selectors/index.js
+// node_modules/css-select/dist/pseudo-selectors/index.js
 function compilePseudoSelector(next, selector, options, context5, compileToken2) {
-  var _a3;
   const { name, data } = selector;
   if (Array.isArray(data)) {
     if (!(name in subselects)) {
@@ -69607,49 +70391,41 @@ function compilePseudoSelector(next, selector, options, context5, compileToken2)
     }
     return subselects[name](next, data, options, context5, compileToken2);
   }
-  const userPseudo = (_a3 = options.pseudos) === null || _a3 === void 0 ? void 0 : _a3[name];
+  const userPseudo = options.pseudos?.[name];
   const stringPseudo = typeof userPseudo === "string" ? userPseudo : aliases[name];
   if (typeof stringPseudo === "string") {
     if (data != null) {
       throw new Error(`Pseudo ${name} doesn't have any arguments`);
     }
-    const alias = (0, import_css_what2.parse)(stringPseudo);
+    const alias = parse3(stringPseudo);
     return subselects["is"](next, alias, options, context5, compileToken2);
   }
   if (typeof userPseudo === "function") {
-    verifyPseudoArgs(userPseudo, name, data, 1);
-    return (elem) => userPseudo(elem, data) && next(elem);
+    verifyPseudoArguments(userPseudo, name, data, 1);
+    return (element) => userPseudo(element, data) && next(element);
   }
   if (name in filters) {
-    return filters[name](next, data, options, context5);
+    return filters[name](next, data, options, context5, compileToken2);
   }
   if (name in pseudos) {
     const pseudo = pseudos[name];
-    verifyPseudoArgs(pseudo, name, data, 2);
-    return (elem) => pseudo(elem, options, data) && next(elem);
+    verifyPseudoArguments(pseudo, name, data, 2);
+    return (element) => pseudo(element, options, data) && next(element);
   }
   throw new Error(`Unknown pseudo-class :${name}`);
 }
 
-// node_modules/css-select/lib/esm/general.js
-var import_css_what3 = __toESM(require_commonjs(), 1);
-function getElementParent(node, adapter2) {
-  const parent = adapter2.getParent(node);
-  if (parent && adapter2.isTag(parent)) {
-    return parent;
-  }
-  return null;
-}
-function compileGeneralSelector(next, selector, options, context5, compileToken2) {
-  const { adapter: adapter2, equals } = options;
+// node_modules/css-select/dist/general.js
+function compileGeneralSelector(next, selector, options, context5, compileToken2, hasExpensiveSubselector) {
+  const { adapter: adapter2, equals, cacheResults } = options;
   switch (selector.type) {
-    case import_css_what3.SelectorType.PseudoElement: {
+    case SelectorType.PseudoElement: {
       throw new Error("Pseudo-elements are not supported by css-select");
     }
-    case import_css_what3.SelectorType.ColumnCombinator: {
+    case SelectorType.ColumnCombinator: {
       throw new Error("Column combinators are not yet supported by css-select");
     }
-    case import_css_what3.SelectorType.Attribute: {
+    case SelectorType.Attribute: {
       if (selector.namespace != null) {
         throw new Error("Namespaced attributes are not yet supported by css-select");
       }
@@ -69658,11 +70434,11 @@ function compileGeneralSelector(next, selector, options, context5, compileToken2
       }
       return attributeRules[selector.action](next, selector, options);
     }
-    case import_css_what3.SelectorType.Pseudo: {
+    case SelectorType.Pseudo: {
       return compilePseudoSelector(next, selector, options, context5, compileToken2);
     }
     // Tags
-    case import_css_what3.SelectorType.Tag: {
+    case SelectorType.Tag: {
       if (selector.namespace != null) {
         throw new Error("Namespaced tag names are not yet supported by css-select");
       }
@@ -69670,15 +70446,15 @@ function compileGeneralSelector(next, selector, options, context5, compileToken2
       if (!options.xmlMode || options.lowerCaseTags) {
         name = name.toLowerCase();
       }
-      return function tag(elem) {
-        return adapter2.getName(elem) === name && next(elem);
+      return function tag(element) {
+        return adapter2.getName(element) === name && next(element);
       };
     }
     // Traversal
-    case import_css_what3.SelectorType.Descendant: {
-      if (options.cacheResults === false || typeof WeakSet === "undefined") {
-        return function descendant(elem) {
-          let current = elem;
+    case SelectorType.Descendant: {
+      if (!hasExpensiveSubselector || cacheResults === false || typeof WeakMap === "undefined") {
+        return function descendant(element) {
+          let current = element;
           while (current = getElementParent(current, adapter2)) {
             if (next(current)) {
               return true;
@@ -69687,48 +70463,59 @@ function compileGeneralSelector(next, selector, options, context5, compileToken2
           return false;
         };
       }
-      const isFalseCache = /* @__PURE__ */ new WeakSet();
-      return function cachedDescendant(elem) {
-        let current = elem;
+      const resultCache = /* @__PURE__ */ new WeakMap();
+      return function cachedDescendant(element) {
+        let current = element;
+        let result;
         while (current = getElementParent(current, adapter2)) {
-          if (!isFalseCache.has(current)) {
-            if (adapter2.isTag(current) && next(current)) {
+          const cached = resultCache.get(current);
+          if (cached === void 0) {
+            result ??= { matches: false };
+            result.matches = next(current);
+            resultCache.set(current, result);
+            if (result.matches) {
               return true;
             }
-            isFalseCache.add(current);
+          } else {
+            if (result) {
+              result.matches = cached.matches;
+            }
+            return cached.matches;
           }
         }
         return false;
       };
     }
     case "_flexibleDescendant": {
-      return function flexibleDescendant(elem) {
-        let current = elem;
+      return function flexibleDescendant(element) {
+        let current = element;
         do {
-          if (next(current))
+          if (next(current)) {
             return true;
-        } while (current = getElementParent(current, adapter2));
+          }
+          current = getElementParent(current, adapter2);
+        } while (current);
         return false;
       };
     }
-    case import_css_what3.SelectorType.Parent: {
-      return function parent(elem) {
-        return adapter2.getChildren(elem).some((elem2) => adapter2.isTag(elem2) && next(elem2));
+    case SelectorType.Parent: {
+      return function parent(element) {
+        return adapter2.getChildren(element).some((element2) => adapter2.isTag(element2) && next(element2));
       };
     }
-    case import_css_what3.SelectorType.Child: {
-      return function child(elem) {
-        const parent = adapter2.getParent(elem);
-        return parent != null && adapter2.isTag(parent) && next(parent);
+    case SelectorType.Child: {
+      return function child(element) {
+        const parent = getElementParent(element, adapter2);
+        return parent !== null && next(parent);
       };
     }
-    case import_css_what3.SelectorType.Sibling: {
-      return function sibling(elem) {
-        const siblings = adapter2.getSiblings(elem);
-        for (let i = 0; i < siblings.length; i++) {
-          const currentSibling = siblings[i];
-          if (equals(elem, currentSibling))
+    case SelectorType.Sibling: {
+      return function sibling(element) {
+        const siblings = adapter2.getSiblings(element);
+        for (const currentSibling of siblings) {
+          if (equals(element, currentSibling)) {
             break;
+          }
           if (adapter2.isTag(currentSibling) && next(currentSibling)) {
             return true;
           }
@@ -69736,20 +70523,20 @@ function compileGeneralSelector(next, selector, options, context5, compileToken2
         return false;
       };
     }
-    case import_css_what3.SelectorType.Adjacent: {
+    case SelectorType.Adjacent: {
       if (adapter2.prevElementSibling) {
-        return function adjacent(elem) {
-          const previous = adapter2.prevElementSibling(elem);
+        return function adjacent(element) {
+          const previous = adapter2.prevElementSibling(element);
           return previous != null && next(previous);
         };
       }
-      return function adjacent(elem) {
-        const siblings = adapter2.getSiblings(elem);
+      return function adjacent(element) {
+        const siblings = adapter2.getSiblings(element);
         let lastElement;
-        for (let i = 0; i < siblings.length; i++) {
-          const currentSibling = siblings[i];
-          if (equals(elem, currentSibling))
+        for (const currentSibling of siblings) {
+          if (equals(element, currentSibling)) {
             break;
+          }
           if (adapter2.isTag(currentSibling)) {
             lastElement = currentSibling;
           }
@@ -69757,7 +70544,7 @@ function compileGeneralSelector(next, selector, options, context5, compileToken2
         return !!lastElement && next(lastElement);
       };
     }
-    case import_css_what3.SelectorType.Universal: {
+    case SelectorType.Universal: {
       if (selector.namespace != null && selector.namespace !== "*") {
         throw new Error("Namespaced universal selectors are not yet supported by css-select");
       }
@@ -69766,34 +70553,20 @@ function compileGeneralSelector(next, selector, options, context5, compileToken2
   }
 }
 
-// node_modules/css-select/lib/esm/compile.js
-function compile2(selector, options, context5) {
-  const next = compileUnsafe(selector, options, context5);
-  return ensureIsTag(next, options.adapter);
-}
-function compileUnsafe(selector, options, context5) {
-  const token = typeof selector === "string" ? (0, import_css_what4.parse)(selector) : selector;
-  return compileToken(token, options, context5);
-}
-function includesScopePseudo(t) {
-  return t.type === import_css_what4.SelectorType.Pseudo && (t.name === "scope" || Array.isArray(t.data) && t.data.some((data) => data.some(includesScopePseudo)));
-}
-var DESCENDANT_TOKEN = { type: import_css_what4.SelectorType.Descendant };
+// node_modules/css-select/dist/compile.js
+var DESCENDANT_TOKEN = { type: SelectorType.Descendant };
 var FLEXIBLE_DESCENDANT_TOKEN = {
   type: "_flexibleDescendant"
 };
 var SCOPE_TOKEN = {
-  type: import_css_what4.SelectorType.Pseudo,
+  type: SelectorType.Pseudo,
   name: "scope",
   data: null
 };
 function absolutize(token, { adapter: adapter2 }, context5) {
-  const hasContext = !!(context5 === null || context5 === void 0 ? void 0 : context5.every((e) => {
-    const parent = adapter2.isTag(e) && adapter2.getParent(e);
-    return e === PLACEHOLDER_ELEMENT || parent && adapter2.isTag(parent);
-  }));
+  const hasContext = !!context5?.every((element) => element === PLACEHOLDER_ELEMENT || adapter2.isTag(element) && getElementParent(element, adapter2) !== null);
   for (const t of token) {
-    if (t.length > 0 && isTraversal(t[0]) && t[0].type !== import_css_what4.SelectorType.Descendant) {
+    if (t.length > 0 && isTraversal2(t[0]) && t[0].type !== SelectorType.Descendant) {
     } else if (hasContext && !t.some(includesScopePseudo)) {
       t.unshift(DESCENDANT_TOKEN);
     } else {
@@ -69802,131 +70575,133 @@ function absolutize(token, { adapter: adapter2 }, context5) {
     t.unshift(SCOPE_TOKEN);
   }
 }
-function compileToken(token, options, context5) {
-  var _a3;
-  token.forEach(sortByProcedure);
-  context5 = (_a3 = options.context) !== null && _a3 !== void 0 ? _a3 : context5;
+function compileToken(token, options, compilationContext) {
+  for (const rules of token) {
+    sortRules(rules);
+  }
+  const { context: context5 = compilationContext, rootFunc: rootFunction = trueFunc } = options;
   const isArrayContext = Array.isArray(context5);
   const finalContext = context5 && (Array.isArray(context5) ? context5 : [context5]);
   if (options.relativeSelector !== false) {
     absolutize(token, options, finalContext);
-  } else if (token.some((t) => t.length > 0 && isTraversal(t[0]))) {
+  } else if (token.some((t) => t.length > 0 && isTraversal2(t[0]))) {
     throw new Error("Relative selectors are not allowed when the `relativeSelector` option is disabled");
   }
   let shouldTestNextSiblings = false;
-  const query2 = token.map((rules) => {
+  let query2 = falseFunc;
+  combineLoop: for (const rules of token) {
     if (rules.length >= 2) {
       const [first, second] = rules;
-      if (first.type !== import_css_what4.SelectorType.Pseudo || first.name !== "scope") {
-      } else if (isArrayContext && second.type === import_css_what4.SelectorType.Descendant) {
+      if (first.type !== SelectorType.Pseudo || first.name !== "scope") {
+      } else if (isArrayContext && second.type === SelectorType.Descendant) {
         rules[1] = FLEXIBLE_DESCENDANT_TOKEN;
-      } else if (second.type === import_css_what4.SelectorType.Adjacent || second.type === import_css_what4.SelectorType.Sibling) {
+      } else if (second.type === SelectorType.Adjacent || second.type === SelectorType.Sibling) {
         shouldTestNextSiblings = true;
       }
     }
-    return compileRules(rules, options, finalContext);
-  }).reduce(reduceRules, import_boolbase5.default.falseFunc);
+    let next = rootFunction;
+    let hasExpensiveSubselector = false;
+    for (const rule of rules) {
+      next = compileGeneralSelector(next, rule, options, finalContext, compileToken, hasExpensiveSubselector);
+      const quality = getQuality(rule);
+      if (quality === 0) {
+        hasExpensiveSubselector = true;
+      }
+      if (next === falseFunc) {
+        continue combineLoop;
+      }
+    }
+    if (next === rootFunction) {
+      return rootFunction;
+    }
+    query2 = query2 === falseFunc ? next : or(query2, next);
+  }
   query2.shouldTestNextSiblings = shouldTestNextSiblings;
   return query2;
 }
-function compileRules(rules, options, context5) {
-  var _a3;
-  return rules.reduce((previous, rule) => previous === import_boolbase5.default.falseFunc ? import_boolbase5.default.falseFunc : compileGeneralSelector(previous, rule, options, context5, compileToken), (_a3 = options.rootFunc) !== null && _a3 !== void 0 ? _a3 : import_boolbase5.default.trueFunc);
-}
-function reduceRules(a, b) {
-  if (b === import_boolbase5.default.falseFunc || a === import_boolbase5.default.trueFunc) {
-    return a;
-  }
-  if (a === import_boolbase5.default.falseFunc || b === import_boolbase5.default.trueFunc) {
-    return b;
-  }
-  return function combine(elem) {
-    return a(elem) || b(elem);
-  };
+function or(a, b) {
+  return (element) => a(element) || b(element);
 }
 
-// node_modules/css-select/lib/esm/index.js
+// node_modules/css-select/dist/index.js
 var defaultEquals = (a, b) => a === b;
 var defaultOptions = {
-  adapter: esm_exports2,
+  adapter: { ...dist_exports2, isTag: isTag4 },
   equals: defaultEquals
 };
 function convertOptionFormats(options) {
-  var _a3, _b, _c, _d;
-  const opts = options !== null && options !== void 0 ? options : defaultOptions;
-  (_a3 = opts.adapter) !== null && _a3 !== void 0 ? _a3 : opts.adapter = esm_exports2;
-  (_b = opts.equals) !== null && _b !== void 0 ? _b : opts.equals = (_d = (_c = opts.adapter) === null || _c === void 0 ? void 0 : _c.equals) !== null && _d !== void 0 ? _d : defaultEquals;
-  return opts;
+  const finalOptions = options ?? defaultOptions;
+  finalOptions.adapter ??= defaultOptions.adapter;
+  finalOptions.equals ??= finalOptions.adapter?.equals ?? defaultEquals;
+  return finalOptions;
 }
-function wrapCompile(func) {
-  return function addAdapter(selector, options, context5) {
-    const opts = convertOptionFormats(options);
-    return func(selector, opts, context5);
-  };
+function compile2(selector, options, context5) {
+  const convertedOptions = convertOptionFormats(options);
+  const next = _compileUnsafe(selector, convertedOptions, context5);
+  return next === falseFunc ? falseFunc : (element) => convertedOptions.adapter.isTag(element) && next(element);
 }
-var compile3 = wrapCompile(compile2);
-var _compileUnsafe = wrapCompile(compileUnsafe);
-var _compileToken = wrapCompile(compileToken);
-function getSelectorFunc(searchFunc) {
+function _compileUnsafe(selector, options, context5) {
+  return compileToken(typeof selector === "string" ? parse3(selector) : selector, convertOptionFormats(options), context5);
+}
+function getSelectorFunction(searchFunction) {
   return function select(query2, elements, options) {
-    const opts = convertOptionFormats(options);
+    const convertedOptions = convertOptionFormats(options);
     if (typeof query2 !== "function") {
-      query2 = compileUnsafe(query2, opts, elements);
+      query2 = _compileUnsafe(query2, convertedOptions, elements);
     }
-    const filteredElements = prepareContext(elements, opts.adapter, query2.shouldTestNextSiblings);
-    return searchFunc(query2, filteredElements, opts);
+    const filteredElements = prepareContext(elements, convertedOptions.adapter, query2.shouldTestNextSiblings);
+    return searchFunction(query2, filteredElements, convertedOptions);
   };
 }
-function prepareContext(elems, adapter2, shouldTestNextSiblings = false) {
+function prepareContext(elements, adapter2, shouldTestNextSiblings = false) {
   if (shouldTestNextSiblings) {
-    elems = appendNextSiblings(elems, adapter2);
+    elements = appendNextSiblings(elements, adapter2);
   }
-  return Array.isArray(elems) ? adapter2.removeSubsets(elems) : adapter2.getChildren(elems);
+  return Array.isArray(elements) ? adapter2.removeSubsets(elements) : adapter2.getChildren(elements);
 }
-function appendNextSiblings(elem, adapter2) {
-  const elems = Array.isArray(elem) ? elem.slice(0) : [elem];
-  const elemsLength = elems.length;
-  for (let i = 0; i < elemsLength; i++) {
-    const nextSiblings = getNextSiblings(elems[i], adapter2);
-    elems.push(...nextSiblings);
+function appendNextSiblings(element, adapter2) {
+  const elements = Array.isArray(element) ? [...element] : [element];
+  const elementsLength = elements.length;
+  for (let index = 0; index < elementsLength; index++) {
+    const nextSiblings = getNextSiblings(elements[index], adapter2);
+    elements.push(...nextSiblings);
   }
-  return elems;
+  return elements;
 }
-var selectAll = getSelectorFunc((query2, elems, options) => query2 === import_boolbase6.default.falseFunc || !elems || elems.length === 0 ? [] : options.adapter.findAll(query2, elems));
-var selectOne = getSelectorFunc((query2, elems, options) => query2 === import_boolbase6.default.falseFunc || !elems || elems.length === 0 ? null : options.adapter.findOne(query2, elems));
-function is2(elem, query2, options) {
-  const opts = convertOptionFormats(options);
-  return (typeof query2 === "function" ? query2 : compile2(query2, opts))(elem);
+var selectAll = getSelectorFunction((query2, elements, options) => query2 === falseFunc || !elements || elements.length === 0 ? [] : findAll3(query2, elements, options));
+var selectOne = getSelectorFunction((query2, elements, options) => query2 === falseFunc || !elements || elements.length === 0 ? null : findOne3(query2, elements, options));
+function is2(element, query2, options) {
+  return (typeof query2 === "function" ? query2 : compile2(query2, options))(element);
 }
 
 // node_modules/linkedom/esm/shared/matches.js
 var { isArray } = Array;
-var isTag3 = ({ nodeType }) => nodeType === ELEMENT_NODE;
-var existsOne2 = (test, elements) => elements.some(
-  (element) => isTag3(element) && (test(element) || existsOne2(test, getChildren2(element)))
+var isTag5 = ({ nodeType }) => nodeType === ELEMENT_NODE;
+var existsOne3 = (test, elements) => elements.some(
+  (element) => isTag5(element) && (test(element) || existsOne3(test, getChildren3(element)))
 );
-var getAttributeValue2 = (element, name) => name === "class" ? element.classList.value : element.getAttribute(name);
-var getChildren2 = ({ childNodes }) => childNodes;
-var getName2 = (element) => {
+var getAttributeValue3 = (element, name) => name === "class" ? element.classList.value : element.getAttribute(name);
+var getChildren3 = ({ childNodes }) => childNodes;
+var getName3 = (element) => {
   const { localName } = element;
   return ignoreCase(element) ? localName.toLowerCase() : localName;
 };
-var getParent2 = ({ parentNode }) => parentNode;
-var getSiblings2 = (element) => {
+var getParent3 = ({ parentNode }) => parentNode;
+var getSiblings3 = (element) => {
   const { parentNode } = element;
-  return parentNode ? getChildren2(parentNode) : element;
+  return parentNode ? getChildren3(parentNode) : element;
 };
-var getText2 = (node) => {
+var getText3 = (node) => {
   if (isArray(node))
-    return node.map(getText2).join("");
-  if (isTag3(node))
-    return getText2(getChildren2(node));
+    return node.map(getText3).join("");
+  if (isTag5(node))
+    return getText3(getChildren3(node));
   if (node.nodeType === TEXT_NODE)
     return node.data;
   return "";
 };
-var hasAttrib2 = (element, name) => element.hasAttribute(name);
-var removeSubsets2 = (nodes) => {
+var hasAttrib3 = (element, name) => element.hasAttribute(name);
+var removeSubsets3 = (nodes) => {
   let { length } = nodes;
   while (length--) {
     const node = nodes[length];
@@ -69943,38 +70718,38 @@ var removeSubsets2 = (nodes) => {
   }
   return nodes;
 };
-var findAll2 = (test, nodes) => {
+var findAll4 = (test, nodes) => {
   const matches2 = [];
   for (const node of nodes) {
-    if (isTag3(node)) {
+    if (isTag5(node)) {
       if (test(node))
         matches2.push(node);
-      matches2.push(...findAll2(test, getChildren2(node)));
+      matches2.push(...findAll4(test, getChildren3(node)));
     }
   }
   return matches2;
 };
-var findOne2 = (test, nodes) => {
+var findOne4 = (test, nodes) => {
   for (let node of nodes)
-    if (test(node) || (node = findOne2(test, getChildren2(node))))
+    if (test(node) || (node = findOne4(test, getChildren3(node))))
       return node;
   return null;
 };
 var adapter = {
-  isTag: isTag3,
-  existsOne: existsOne2,
-  getAttributeValue: getAttributeValue2,
-  getChildren: getChildren2,
-  getName: getName2,
-  getParent: getParent2,
-  getSiblings: getSiblings2,
-  getText: getText2,
-  hasAttrib: hasAttrib2,
-  removeSubsets: removeSubsets2,
-  findAll: findAll2,
-  findOne: findOne2
+  isTag: isTag5,
+  existsOne: existsOne3,
+  getAttributeValue: getAttributeValue3,
+  getChildren: getChildren3,
+  getName: getName3,
+  getParent: getParent3,
+  getSiblings: getSiblings3,
+  getText: getText3,
+  hasAttrib: hasAttrib3,
+  removeSubsets: removeSubsets3,
+  findAll: findAll4,
+  findOne: findOne4
 };
-var prepareMatch = (element, selectors) => compile3(
+var prepareMatch = (element, selectors) => compile2(
   selectors,
   {
     context: selectors.includes(":scope") ? element : void 0,
@@ -69994,7 +70769,7 @@ var matches = (element, selectors) => is2(
 );
 
 // node_modules/linkedom/esm/interface/text.js
-var Text3 = class _Text extends CharacterData {
+var Text4 = class _Text extends CharacterData {
   constructor(ownerDocument, data = "") {
     super(ownerDocument, "#text", TEXT_NODE, data);
   }
@@ -70033,7 +70808,7 @@ var insert = (parentNode, child, nodes) => {
   const { ownerDocument } = parentNode;
   for (const node of nodes)
     parentNode.insertBefore(
-      isNode(node) ? node : new Text3(ownerDocument, node),
+      isNode(node) ? node : new Text4(ownerDocument, node),
       child
     );
 };
@@ -70504,7 +71279,7 @@ var handler3 = {
       return getKeys(style).length;
     if (/^\d+$/.test(name))
       return getKeys(style)[name];
-    return style.get(esm_default2(name));
+    return style.get(esm_default2(name)) ?? "";
   },
   set(style, name, value) {
     if (name === "cssText")
@@ -70844,7 +71619,7 @@ var Element2 = class extends ParentNode {
   set textContent(text) {
     this.replaceChildren();
     if (text != null && text !== "")
-      this.appendChild(new Text3(this.ownerDocument, text));
+      this.appendChild(new Text4(this.ownerDocument, text));
   }
   get innerHTML() {
     return getInnerHtml(this);
@@ -70863,13 +71638,13 @@ var Element2 = class extends ParentNode {
   // </contentRelated>
   // <attributes>
   get attributes() {
-    const attributes2 = new NamedNodeMap(this);
+    const attributes = new NamedNodeMap(this);
     let next = this[NEXT];
     while (next.nodeType === ATTRIBUTE_NODE) {
-      attributes2.push(next);
+      attributes.push(next);
       next = next[NEXT];
     }
-    return new Proxy(attributes2, attributesHandler);
+    return new Proxy(attributes, attributesHandler);
   }
   focus() {
     this.dispatchEvent(new GlobalEvent("focus"));
@@ -70890,13 +71665,13 @@ var Element2 = class extends ParentNode {
     return null;
   }
   getAttributeNames() {
-    const attributes2 = new NodeList();
+    const attributes = new NodeList();
     let next = this[NEXT];
     while (next.nodeType === ATTRIBUTE_NODE) {
-      attributes2.push(next.name);
+      attributes.push(next.name);
       next = next[NEXT];
     }
-    return attributes2;
+    return attributes;
   }
   hasAttribute(name) {
     return !!this.getAttributeNode(name);
@@ -71218,11 +71993,11 @@ function CharacterData2() {
 }
 setPrototypeOf(CharacterData2, CharacterData);
 CharacterData2.prototype = CharacterData.prototype;
-function Comment4() {
+function Comment5() {
   illegalConstructor();
 }
-setPrototypeOf(Comment4, Comment3);
-Comment4.prototype = Comment3.prototype;
+setPrototypeOf(Comment5, Comment3);
+Comment5.prototype = Comment3.prototype;
 function DocumentFragment2() {
   illegalConstructor();
 }
@@ -71248,11 +72023,11 @@ function ShadowRoot2() {
 }
 setPrototypeOf(ShadowRoot2, ShadowRoot);
 ShadowRoot2.prototype = ShadowRoot.prototype;
-function Text4() {
+function Text5() {
   illegalConstructor();
 }
-setPrototypeOf(Text4, Text3);
-Text4.prototype = Text3.prototype;
+setPrototypeOf(Text5, Text4);
+Text5.prototype = Text4.prototype;
 function SVGElement3() {
   illegalConstructor();
 }
@@ -71262,13 +72037,13 @@ var Facades = {
   Attr: Attr2,
   CDATASection: CDATASection2,
   CharacterData: CharacterData2,
-  Comment: Comment4,
+  Comment: Comment5,
   DocumentFragment: DocumentFragment2,
   DocumentType: DocumentType2,
   Element: Element3,
   Node: Node3,
   ShadowRoot: ShadowRoot2,
-  Text: Text4,
+  Text: Text5,
   SVGElement: SVGElement3
 };
 
@@ -72925,7 +73700,7 @@ var HTMLClasses = {
 };
 
 // node_modules/linkedom/esm/shared/mime.js
-var voidElements2 = { test: () => true };
+var voidElements3 = { test: () => true };
 var Mime = {
   "text/html": {
     docType: "<!DOCTYPE html>",
@@ -72935,22 +73710,22 @@ var Mime = {
   "image/svg+xml": {
     docType: '<?xml version="1.0" encoding="utf-8"?>',
     ignoreCase: false,
-    voidElements: voidElements2
+    voidElements: voidElements3
   },
   "text/xml": {
     docType: '<?xml version="1.0" encoding="utf-8"?>',
     ignoreCase: false,
-    voidElements: voidElements2
+    voidElements: voidElements3
   },
   "application/xml": {
     docType: '<?xml version="1.0" encoding="utf-8"?>',
     ignoreCase: false,
-    voidElements: voidElements2
+    voidElements: voidElements3
   },
   "application/xhtml+xml": {
     docType: '<?xml version="1.0" encoding="utf-8"?>',
     ignoreCase: false,
-    voidElements: voidElements2
+    voidElements: voidElements3
   }
 };
 
@@ -73266,8 +74041,8 @@ var Document2 = class extends NonElementParentNode {
   createCDATASection(data) {
     return new CDATASection(this, data);
   }
-  createComment(textContent2) {
-    return new Comment3(this, textContent2);
+  createComment(textContent3) {
+    return new Comment3(this, textContent3);
   }
   createDocumentFragment() {
     return new DocumentFragment(this);
@@ -73283,8 +74058,8 @@ var Document2 = class extends NonElementParentNode {
     range2.commonAncestorContainer = this;
     return range2;
   }
-  createTextNode(textContent2) {
-    return new Text3(this, textContent2);
+  createTextNode(textContent3) {
+    return new Text4(this, textContent3);
   }
   createTreeWalker(root2, whatToShow = -1) {
     return new TreeWalker(root2, whatToShow);
@@ -73431,12 +74206,12 @@ var HTMLDocument = class extends Document2 {
    */
   get body() {
     const { head } = this;
-    let { nextElementSibling: nextElementSibling3 } = head;
-    if (!nextElementSibling3 || nextElementSibling3.tagName !== "BODY") {
-      nextElementSibling3 = this.createElement("body");
-      head.after(nextElementSibling3);
+    let { nextElementSibling: nextElementSibling4 } = head;
+    if (!nextElementSibling4 || nextElementSibling4.tagName !== "BODY") {
+      nextElementSibling4 = this.createElement("body");
+      head.after(nextElementSibling4);
     }
-    return nextElementSibling3;
+    return nextElementSibling4;
   }
   /**
    * @type HTMLTitleElement
@@ -73445,16 +74220,16 @@ var HTMLDocument = class extends Document2 {
     const { head } = this;
     return head.getElementsByTagName("title").at(0)?.textContent || "";
   }
-  set title(textContent2) {
+  set title(textContent3) {
     const { head } = this;
     let title = head.getElementsByTagName("title").at(0);
     if (title)
-      title.textContent = textContent2;
+      title.textContent = textContent3;
     else {
       head.insertBefore(
         this.createElement("title"),
         head.firstChild
-      ).textContent = textContent2;
+      ).textContent = textContent3;
     }
   }
   createElement(localName, options) {
@@ -73514,7 +74289,7 @@ var DOMParser = class _DOMParser {
 };
 
 // node_modules/linkedom/esm/shared/parse-json.js
-var { parse: parse7 } = JSON;
+var { parse: parse6 } = JSON;
 
 // node_modules/linkedom/esm/index.js
 var parseHTML = (html, globals = null) => new DOMParser().parseFromString(
@@ -73702,10 +74477,10 @@ function childMatcher(selector) {
 }
 
 // node_modules/d3-selection/src/selection/selectChild.js
-var find2 = Array.prototype.find;
+var find3 = Array.prototype.find;
 function childFind(match) {
   return function() {
-    return find2.call(this.children, match);
+    return find3.call(this.children, match);
   };
 }
 function childFirst() {
@@ -73716,13 +74491,13 @@ function selectChild_default(match) {
 }
 
 // node_modules/d3-selection/src/selection/selectChildren.js
-var filter2 = Array.prototype.filter;
+var filter3 = Array.prototype.filter;
 function children() {
   return Array.from(this.children);
 }
 function childrenFilter(match) {
   return function() {
-    return filter2.call(this.children, match);
+    return filter3.call(this.children, match);
   };
 }
 function selectChildren_default(match) {
@@ -74910,7 +75685,7 @@ function parseSvg(value) {
 }
 
 // node_modules/d3-interpolate/src/transform/index.js
-function interpolateTransform(parse9, pxComma, pxParen, degParen) {
+function interpolateTransform(parse8, pxComma, pxParen, degParen) {
   function pop(s) {
     return s.length ? s.pop() + " " : "";
   }
@@ -74948,7 +75723,7 @@ function interpolateTransform(parse9, pxComma, pxParen, degParen) {
   }
   return function(a, b) {
     var s = [], q = [];
-    a = parse9(a), b = parse9(b);
+    a = parse8(a), b = parse8(b);
     translate(a.translateX, a.translateY, b.translateX, b.translateY, s, q);
     rotate(a.rotate, b.rotate, s, q);
     skewX(a.skewX, b.skewX, s, q);
@@ -77087,13 +77862,13 @@ async function __wbg_init(input) {
   const { instance, module } = await __wbg_load(await input, imports);
   return __wbg_finalize_init(instance, module);
 }
-var dist_default = __wbg_init;
+var dist_default2 = __wbg_init;
 var initialized = false;
 var initWasm = async (module_or_path) => {
   if (initialized) {
     throw new Error("Already initialized. The `initWasm()` function can be used only once.");
   }
-  await dist_default(await module_or_path);
+  await dist_default2(await module_or_path);
   initialized = true;
 };
 var Resvg2 = class extends Resvg {
@@ -77276,13 +78051,13 @@ import * as fs9 from "fs";
 import * as path5 from "path";
 
 // node_modules/@actions/artifact/lib/generated/google/protobuf/timestamp.js
-var import_runtime2 = __toESM(require_commonjs2(), 1);
-var import_runtime3 = __toESM(require_commonjs2(), 1);
-var import_runtime4 = __toESM(require_commonjs2(), 1);
-var import_runtime5 = __toESM(require_commonjs2(), 1);
-var import_runtime6 = __toESM(require_commonjs2(), 1);
-var import_runtime7 = __toESM(require_commonjs2(), 1);
-var import_runtime8 = __toESM(require_commonjs2(), 1);
+var import_runtime2 = __toESM(require_commonjs(), 1);
+var import_runtime3 = __toESM(require_commonjs(), 1);
+var import_runtime4 = __toESM(require_commonjs(), 1);
+var import_runtime5 = __toESM(require_commonjs(), 1);
+var import_runtime6 = __toESM(require_commonjs(), 1);
+var import_runtime7 = __toESM(require_commonjs(), 1);
+var import_runtime8 = __toESM(require_commonjs(), 1);
 var Timestamp$Type = class extends import_runtime8.MessageType {
   constructor() {
     super("google.protobuf.Timestamp", [
@@ -77418,13 +78193,13 @@ var Timestamp$Type = class extends import_runtime8.MessageType {
 var Timestamp = new Timestamp$Type();
 
 // node_modules/@actions/artifact/lib/generated/google/protobuf/wrappers.js
-var import_runtime9 = __toESM(require_commonjs2(), 1);
-var import_runtime10 = __toESM(require_commonjs2(), 1);
-var import_runtime11 = __toESM(require_commonjs2(), 1);
-var import_runtime12 = __toESM(require_commonjs2(), 1);
-var import_runtime13 = __toESM(require_commonjs2(), 1);
-var import_runtime14 = __toESM(require_commonjs2(), 1);
-var import_runtime15 = __toESM(require_commonjs2(), 1);
+var import_runtime9 = __toESM(require_commonjs(), 1);
+var import_runtime10 = __toESM(require_commonjs(), 1);
+var import_runtime11 = __toESM(require_commonjs(), 1);
+var import_runtime12 = __toESM(require_commonjs(), 1);
+var import_runtime13 = __toESM(require_commonjs(), 1);
+var import_runtime14 = __toESM(require_commonjs(), 1);
+var import_runtime15 = __toESM(require_commonjs(), 1);
 var DoubleValue$Type = class extends import_runtime15.MessageType {
   constructor() {
     super("google.protobuf.DoubleValue", [
@@ -78003,12 +78778,12 @@ var BytesValue$Type = class extends import_runtime15.MessageType {
 var BytesValue = new BytesValue$Type();
 
 // node_modules/@actions/artifact/lib/generated/results/api/v1/artifact.js
-var import_runtime_rpc = __toESM(require_commonjs3(), 1);
-var import_runtime16 = __toESM(require_commonjs2(), 1);
-var import_runtime17 = __toESM(require_commonjs2(), 1);
-var import_runtime18 = __toESM(require_commonjs2(), 1);
-var import_runtime19 = __toESM(require_commonjs2(), 1);
-var import_runtime20 = __toESM(require_commonjs2(), 1);
+var import_runtime_rpc = __toESM(require_commonjs2(), 1);
+var import_runtime16 = __toESM(require_commonjs(), 1);
+var import_runtime17 = __toESM(require_commonjs(), 1);
+var import_runtime18 = __toESM(require_commonjs(), 1);
+var import_runtime19 = __toESM(require_commonjs(), 1);
+var import_runtime20 = __toESM(require_commonjs(), 1);
 var CreateArtifactRequest$Type = class extends import_runtime20.MessageType {
   constructor() {
     super("github.actions.results.api.v1.CreateArtifactRequest", [
@@ -83105,7 +83880,7 @@ function shouldDeserializeResponse(parsedResponse) {
   return result;
 }
 async function deserializeResponseBody(jsonContentTypes, xmlContentTypes, response, options, parseXML2) {
-  const parsedResponse = await parse8(jsonContentTypes, xmlContentTypes, response, options, parseXML2);
+  const parsedResponse = await parse7(jsonContentTypes, xmlContentTypes, response, options, parseXML2);
   if (!shouldDeserializeResponse(parsedResponse)) {
     return parsedResponse;
   }
@@ -83206,7 +83981,7 @@ function handleErrorResponse(parsedResponse, operationSpec, responseSpec, option
   }
   return { error: error2, shouldReturnResponse: false };
 }
-async function parse8(jsonContentTypes, xmlContentTypes, operationResponse, opts, parseXML2) {
+async function parse7(jsonContentTypes, xmlContentTypes, operationResponse, opts, parseXML2) {
   if (!operationResponse.request.streamResponseStatusCodes?.has(operationResponse.status) && operationResponse.bodyAsText) {
     const text = operationResponse.bodyAsText;
     const contentType2 = operationResponse.headers.get("Content-Type") || "";
@@ -89189,7 +89964,7 @@ function safeComment(val) {
 function safeCdata(val) {
   return String(val).replace(/\]\]>/g, "]]]]><![CDATA[>");
 }
-function escapeAttribute2(val) {
+function escapeAttribute3(val) {
   return String(val).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
 }
 
@@ -89334,7 +90109,7 @@ function extractAttributeValues(attrMap, options) {
   for (let attr in attrMap) {
     if (!Object.prototype.hasOwnProperty.call(attrMap, attr)) continue;
     const cleanAttrName = attr.startsWith(options.attributeNamePrefix) ? attr.substr(options.attributeNamePrefix.length) : attr;
-    attrValues[cleanAttrName] = escapeAttribute2(attrMap[attr]);
+    attrValues[cleanAttrName] = escapeAttribute3(attrMap[attr]);
     hasAttrs = true;
   }
   return hasAttrs ? attrValues : null;
@@ -89379,7 +90154,7 @@ function attr_to_str_raw(attrMap, options) {
       if (attrVal === true && options.suppressBooleanAttributes) {
         attrStr += ` ${attr.substr(options.attributeNamePrefix.length)}`;
       } else {
-        attrStr += ` ${attr.substr(options.attributeNamePrefix.length)}="${escapeAttribute2(attrVal)}"`;
+        attrStr += ` ${attr.substr(options.attributeNamePrefix.length)}="${escapeAttribute3(attrVal)}"`;
       }
     }
   }
@@ -89410,7 +90185,7 @@ function attr_to_str(attrMap, options, isStopNode, matcher, xmlVersion) {
       if (attrVal === true && options.suppressBooleanAttributes) {
         attrStr += ` ${resolvedAttrName}`;
       } else {
-        attrStr += ` ${resolvedAttrName}="${escapeAttribute2(attrVal)}"`;
+        attrStr += ` ${resolvedAttrName}="${escapeAttribute3(attrVal)}"`;
       }
     }
   }
@@ -89695,7 +90470,7 @@ Builder.prototype.buildAttrPairStr = function(attrName, val, isStopNode) {
   }
   if (this.options.suppressBooleanAttributes && val === "true") {
     return " " + attrName;
-  } else return " " + attrName + '="' + escapeAttribute2(val) + '"';
+  } else return " " + attrName + '="' + escapeAttribute3(val) + '"';
 };
 function processTextOrObjNode(object, key2, level, matcher, xmlVersion) {
   const attrValues = this.extractAttributes(object);
@@ -89726,7 +90501,7 @@ Builder.prototype.extractAttributes = function(obj) {
     for (let attrKey in attrGroup) {
       if (!Object.prototype.hasOwnProperty.call(attrGroup, attrKey)) continue;
       const cleanKey = attrKey.startsWith(this.options.attributeNamePrefix) ? attrKey.substring(this.options.attributeNamePrefix.length) : attrKey;
-      attrValues[cleanKey] = escapeAttribute2(attrGroup[attrKey]);
+      attrValues[cleanKey] = escapeAttribute3(attrGroup[attrKey]);
       hasAttrs = true;
     }
   } else {
@@ -89734,7 +90509,7 @@ Builder.prototype.extractAttributes = function(obj) {
       if (!Object.prototype.hasOwnProperty.call(obj, key2)) continue;
       const attr = this.isAttribute(key2);
       if (attr) {
-        attrValues[attr] = escapeAttribute2(obj[key2]);
+        attrValues[attr] = escapeAttribute3(obj[key2]);
         hasAttrs = true;
       }
     }
@@ -108602,7 +109377,7 @@ function escapeURLPath(url2) {
   const urlParsed = new URL(url2);
   let path8 = urlParsed.pathname;
   path8 = path8 || "/";
-  path8 = escape3(path8);
+  path8 = escape4(path8);
   urlParsed.pathname = path8;
   return urlParsed.toString();
 }
@@ -108683,7 +109458,7 @@ function extractConnectionStringParts(connectionString) {
     return { kind: "SASConnString", url: blobEndpoint, accountName, accountSas };
   }
 }
-function escape3(text) {
+function escape4(text) {
   return encodeURIComponent(text).replace(/%2F/g, "/").replace(/'/g, "%27").replace(/\+/g, "%20").replace(/%25/g, "%");
 }
 function appendToURLPath(url2, name) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,24 +12,24 @@
         "d3": "^7.9.0",
         "d3-hierarchy": "^3.1.2",
         "dejavu-fonts-ttf": "2.37.3",
-        "linkedom": "0.18.12",
-        "picomatch": "^4.0.4"
+        "linkedom": "0.18.13",
+        "picomatch": "^4.0.5"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@types/d3": "^7.4.3",
         "@types/jest": "^30.0.0",
-        "@types/node": "25.9.3",
+        "@types/node": "26.1.1",
         "@types/picomatch": "^4.0.3",
-        "@typescript-eslint/eslint-plugin": "^8.61.1",
-        "@typescript-eslint/parser": "^8.61.1",
+        "@typescript-eslint/eslint-plugin": "^8.63.0",
+        "@typescript-eslint/parser": "^8.63.0",
         "esbuild": "0.28.1",
-        "eslint": "10.5.0",
+        "eslint": "10.6.0",
         "jest": "^30.0.0",
-        "prettier": "^3.3.3",
+        "prettier": "^3.9.4",
         "ts-jest": "^29.2.5",
         "typescript": "6.0.3",
-        "typescript-eslint": "8.61.1"
+        "typescript-eslint": "8.63.0"
       },
       "license": "MIT",
       "name": "coveragemap-action",
@@ -1556,16 +1556,6 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "version": "1.1.0"
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      },
-      "dev": true,
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "version": "1.0.10"
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -1579,20 +1569,6 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "version": "4.1.0"
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      },
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "dev": true,
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "version": "3.14.2"
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "dependencies": {
@@ -2847,20 +2823,13 @@
     },
     "node_modules/@types/node": {
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       },
       "dev": true,
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "version": "25.9.3"
-    },
-    "node_modules/@types/node/node_modules/undici-types": {
-      "dev": true,
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "version": "7.24.6"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "version": "26.1.1"
     },
     "node_modules/@types/picomatch": {
       "dev": true,
@@ -2896,10 +2865,10 @@
     "node_modules/@typescript-eslint/eslint-plugin": {
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/type-utils": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2912,22 +2881,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.1",
+        "@typescript-eslint/parser": "^8.63.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       },
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/parser": {
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3"
       },
       "dev": true,
@@ -2938,19 +2907,19 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       },
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/project-service": {
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.1",
-        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
         "debug": "^4.4.3"
       },
       "dev": true,
@@ -2961,18 +2930,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
       },
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1"
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
       },
       "dev": true,
       "engines": {
@@ -2982,10 +2951,10 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "dev": true,
@@ -2996,19 +2965,19 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
       },
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/type-utils": {
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -3020,14 +2989,14 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       },
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/types": {
       "dev": true,
@@ -3038,17 +3007,17 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.1",
-        "@typescript-eslint/tsconfig-utils": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -3063,20 +3032,20 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
       },
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/utils": {
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1"
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
       },
       "dev": true,
       "engines": {
@@ -3086,18 +3055,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       },
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/types": "8.63.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "dev": true,
@@ -3108,10 +3077,10 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "dev": true,
@@ -3651,6 +3620,16 @@
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
       "version": "5.0.2"
     },
+    "node_modules/argparse": {
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      },
+      "dev": true,
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "version": "1.0.10"
+    },
     "node_modules/async": {
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT",
@@ -3925,10 +3904,17 @@
       "version": "0.3.0"
     },
     "node_modules/boolbase": {
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      },
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
       "license": "ISC",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "version": "1.0.0"
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "version": "2.0.0"
     },
     "node_modules/bottleneck": {
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
@@ -4370,31 +4356,103 @@
     },
     "node_modules/css-select": {
       "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "funding": {
+        "type": "github",
         "url": "https://github.com/sponsors/fb55"
       },
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
       "license": "BSD-2-Clause",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "version": "5.2.2"
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "version": "7.0.0"
+    },
+    "node_modules/css-select/node_modules/dom-serializer": {
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      },
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "version": "3.1.1"
+    },
+    "node_modules/css-select/node_modules/domelementtype": {
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "version": "3.0.0"
+    },
+    "node_modules/css-select/node_modules/domhandler": {
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      },
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "version": "6.0.1"
+    },
+    "node_modules/css-select/node_modules/domutils": {
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      },
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "version": "4.0.2"
     },
     "node_modules/css-what": {
       "engines": {
-        "node": ">= 6"
+        "node": ">=20.19.0"
       },
       "funding": {
+        "type": "github",
         "url": "https://github.com/sponsors/fb55"
       },
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
       "license": "BSD-2-Clause",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "version": "6.2.2"
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "version": "8.0.0"
     },
     "node_modules/cssom": {
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
@@ -4976,6 +5034,18 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "version": "9.2.2"
     },
+    "node_modules/entities": {
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      },
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "version": "8.0.0"
+    },
     "node_modules/error-ex": {
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -5094,7 +5164,7 @@
       "funding": {
         "url": "https://eslint.org/donate"
       },
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "license": "MIT",
       "peerDependencies": {
         "jiti": "*"
@@ -5104,8 +5174,8 @@
           "optional": true
         }
       },
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "version": "10.6.0",
       "workspaces": [
         "packages/*"
       ]
@@ -6601,6 +6671,20 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "version": "4.0.0"
     },
+    "node_modules/js-yaml": {
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      },
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "dev": true,
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "version": "3.15.0"
+    },
     "node_modules/jsesc": {
       "bin": {
         "jsesc": "bin/jsesc"
@@ -6755,16 +6839,16 @@
     },
     "node_modules/linkedom": {
       "dependencies": {
-        "css-select": "^5.1.0",
+        "css-select": "^7.0.0",
         "cssom": "^0.5.0",
         "html-escaper": "^3.0.3",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "uhyphen": "^0.2.0"
       },
       "engines": {
         "node": ">=16"
       },
-      "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
       "license": "ISC",
       "peerDependencies": {
         "canvas": ">= 2"
@@ -6774,8 +6858,8 @@
           "optional": true
         }
       },
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
-      "version": "0.18.12"
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "version": "0.18.13"
     },
     "node_modules/linkedom/node_modules/html-escaper": {
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
@@ -6995,15 +7079,19 @@
     },
     "node_modules/nth-check": {
       "dependencies": {
-        "boolbase": "^1.0.0"
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "funding": {
+        "type": "github",
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       },
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
       "license": "BSD-2-Clause",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "version": "2.1.1"
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "version": "3.0.1"
     },
     "node_modules/once": {
       "dependencies": {
@@ -7196,10 +7284,10 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       },
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "version": "4.0.4"
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "version": "4.0.5"
     },
     "node_modules/pirates": {
       "dev": true,
@@ -7301,10 +7389,10 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       },
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "version": "3.8.4"
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "version": "3.9.4"
     },
     "node_modules/pretty-format": {
       "dependencies": {
@@ -8138,10 +8226,10 @@
     },
     "node_modules/typescript-eslint": {
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.1",
-        "@typescript-eslint/parser": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1"
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0"
       },
       "dev": true,
       "engines": {
@@ -8151,14 +8239,14 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       },
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
-      "version": "8.61.1"
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+      "version": "8.63.0"
     },
     "node_modules/uglify-js": {
       "bin": {
@@ -8188,6 +8276,13 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
       "version": "6.27.0"
+    },
+    "node_modules/undici-types": {
+      "dev": true,
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "version": "8.3.0"
     },
     "node_modules/universal-github-app-jwt": {
       "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",

--- a/package.json
+++ b/package.json
@@ -9,25 +9,25 @@
     "d3": "^7.9.0",
     "d3-hierarchy": "^3.1.2",
     "dejavu-fonts-ttf": "2.37.3",
-    "linkedom": "0.18.12",
-    "picomatch": "^4.0.4"
+    "linkedom": "0.18.13",
+    "picomatch": "^4.0.5"
   },
   "description": "GitHub Action that analyzes code coverage for files changed in a pull request and generates a visual treemap",
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/d3": "^7.4.3",
     "@types/jest": "^30.0.0",
-    "@types/node": "25.9.3",
+    "@types/node": "26.1.1",
     "@types/picomatch": "^4.0.3",
-    "@typescript-eslint/eslint-plugin": "^8.61.1",
-    "@typescript-eslint/parser": "^8.61.1",
+    "@typescript-eslint/eslint-plugin": "^8.63.0",
+    "@typescript-eslint/parser": "^8.63.0",
     "esbuild": "0.28.1",
-    "eslint": "10.5.0",
+    "eslint": "10.6.0",
     "jest": "^30.0.0",
-    "prettier": "^3.3.3",
+    "prettier": "^3.9.4",
     "ts-jest": "^29.2.5",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.61.1"
+    "typescript-eslint": "8.63.0"
   },
   "keywords": [
     "github-action",


### PR DESCRIPTION
## Summary

Bumps all dependencies to their latest versions.

### npm

| Package | From | To |
|---|---|---|
| `@types/node` | 25.9.3 | 26.1.1 |
| `eslint` | 10.5.0 | 10.6.0 |
| `typescript-eslint` / `@typescript-eslint/*` | 8.61.1 | 8.63.0 |
| `prettier` | ^3.3.3 (3.8.4) | ^3.9.4 |
| `picomatch` | ^4.0.4 | ^4.0.5 |
| `linkedom` | 0.18.12 | 0.18.13 |

`npm audit fix` also resolved a moderate js-yaml advisory (transitive via jest) — `npm audit` is now clean.

**Not bumped:** TypeScript stays at 6.0.3 because `typescript-eslint@8.63.0` requires `typescript <6.1.0`.

### GitHub Actions (digest-pinned)

| Action | From | To |
|---|---|---|
| `actions/checkout` | v5.0.1 | v7.0.0 |
| `actions/dependency-review-action` | v4.9.0 | v5.0.0 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |
| `github/codeql-action` | v3.36.2 | v4.37.0 |

`actions/setup-node` and `pre-commit/action` were already at their latest releases.

### pre-commit hooks

`pre-commit autoupdate` across all hooks. Two adjustments:

- `mirrors-prettier` kept at v3.1.0 — the newest tag is a v4 alpha.
- markdownlint v0.49 introduces MD060 (table pipe alignment), which flags all existing README tables; disabled it in `.markdownlint.yaml` instead of reformatting every table.

## Testing

`npm run lint && npm run test && npm run build && npm run package` — 262 tests pass; `pre-commit run --all-files` passes with the updated hook revs.